### PR TITLE
feat: auto-reindex — incremental repo reindexing triggered by git state

### DIFF
--- a/src/ast/index-worker.ts
+++ b/src/ast/index-worker.ts
@@ -7,6 +7,7 @@
 // This module exports parseFileWithRetry for direct testing.
 // When run as a worker thread, it listens on parentPort (Node) or self.onmessage (Bun) for messages.
 
+import { createHash } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { dispatchExtractionAsync } from "@/ast/extractors/tier-dispatch";
 import { getLanguageForFile } from "@/ast/languages";
@@ -23,6 +24,8 @@ export interface WorkerMessage {
 export interface WorkerResult {
 	relPath: string;
 	mtimeMs: number;
+	/** SHA-256 truncated to 16 hex chars — lets cache skip unchanged content. */
+	contentHash?: string;
 	packagePath: string | null;
 	facts: CandidateFact[];
 	error?: string;
@@ -44,6 +47,7 @@ export async function parseFileWithRetry(absPath: string, relPath: string): Prom
 		try {
 			const stat = statSync(absPath);
 			const content = readFileSync(absPath, "utf-8");
+			const contentHash = createHash("sha256").update(content).digest("hex").slice(0, 16);
 			const facts = await dispatchExtractionAsync(
 				content,
 				relPath,
@@ -56,6 +60,7 @@ export async function parseFileWithRetry(absPath: string, relPath: string): Prom
 			return {
 				relPath,
 				mtimeMs: stat.mtimeMs,
+				contentHash,
 				packagePath,
 				// Convert to plain objects for structured clone across threads
 				facts: facts.map((f) => ({ ...f })),

--- a/src/ast/indexer.ts
+++ b/src/ast/indexer.ts
@@ -583,6 +583,12 @@ export async function indexRepository(
 	if (head) {
 		const repoDataDir = join(config.repoDir, repoHash);
 		writeStoredHead(repoDataDir, head);
+
+		// Backward compat: also write .sia-graph/last-indexed-commit
+		const siaGraphDir = join(root, ".sia-graph");
+		if (existsSync(siaGraphDir)) {
+			writeFileSync(join(siaGraphDir, "last-indexed-commit"), head, "utf-8");
+		}
 	}
 
 	return {

--- a/src/ast/indexer.ts
+++ b/src/ast/indexer.ts
@@ -258,7 +258,10 @@ async function processResult(
 	}
 
 	if (!ctx.dryRun) {
-		ctx.cache[result.relPath] = { mtimeMs: result.mtimeMs };
+		ctx.cache[result.relPath] = {
+			mtimeMs: result.mtimeMs,
+			...(result.contentHash ? { contentHash: result.contentHash } : {}),
+		};
 	}
 
 	filesProcessed++;

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -36,6 +36,8 @@ export interface HookResponse {
 	nodes_created?: number;
 	edges_created?: number;
 	error?: string;
+	/** Set by PostToolUse(Bash) after a git-mutating command triggers incremental reindex. */
+	reindex_message?: string;
 	[key: string]: unknown;
 }
 

--- a/tests/unit/capture/incremental-reindexer.test.ts
+++ b/tests/unit/capture/incremental-reindexer.test.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	computeContentHash,
+	filterSupportedFiles,
+	getChangedFiles,
+} from "@/capture/incremental-reindexer";
+
+describe("incremental-reindexer", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "sia-reindex-test-"));
+		execFileSync("git", ["init", "-b", "main"], { cwd: tempDir });
+		execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: tempDir });
+		execFileSync("git", ["config", "user.name", "Test"], { cwd: tempDir });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	describe("getChangedFiles", () => {
+		it("returns changed files between two commits", () => {
+			writeFileSync(join(tempDir, "a.ts"), "export const a = 1;");
+			execFileSync("git", ["add", "."], { cwd: tempDir });
+			execFileSync("git", ["commit", "-m", "init"], { cwd: tempDir });
+			const oldHead = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: tempDir,
+				encoding: "utf-8",
+			}).trim();
+
+			writeFileSync(join(tempDir, "b.ts"), "export const b = 2;");
+			writeFileSync(join(tempDir, "a.ts"), "export const a = 2;");
+			execFileSync("git", ["add", "."], { cwd: tempDir });
+			execFileSync("git", ["commit", "-m", "second"], { cwd: tempDir });
+			const newHead = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: tempDir,
+				encoding: "utf-8",
+			}).trim();
+
+			const changed = getChangedFiles(tempDir, oldHead, newHead);
+			expect(changed.sort()).toEqual(["a.ts", "b.ts"]);
+		});
+
+		it("returns empty array when commits are the same", () => {
+			writeFileSync(join(tempDir, "a.ts"), "export const a = 1;");
+			execFileSync("git", ["add", "."], { cwd: tempDir });
+			execFileSync("git", ["commit", "-m", "init"], { cwd: tempDir });
+			const head = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: tempDir,
+				encoding: "utf-8",
+			}).trim();
+
+			const changed = getChangedFiles(tempDir, head, head);
+			expect(changed).toEqual([]);
+		});
+	});
+
+	describe("filterSupportedFiles", () => {
+		it("filters to known extensions", () => {
+			const files = ["src/a.ts", "src/b.py", "README.md", "image.png", "data.json"];
+			const supported = filterSupportedFiles(files);
+			// The exact set depends on the language registry — verify known-supported
+			// extensions pass and image.png is excluded.
+			expect(supported).toContain("src/a.ts");
+			expect(supported).toContain("src/b.py");
+			expect(supported).not.toContain("image.png");
+		});
+	});
+
+	describe("computeContentHash", () => {
+		it("returns consistent 16-char hex hash", () => {
+			const hash = computeContentHash("hello world");
+			expect(hash).toHaveLength(16);
+			expect(hash).toMatch(/^[0-9a-f]{16}$/);
+			expect(computeContentHash("hello world")).toBe(hash);
+		});
+
+		it("returns different hash for different content", () => {
+			expect(computeContentHash("a")).not.toBe(computeContentHash("b"));
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements automatic incremental repo reindexing with no user intervention: triggered by Claude Code SessionStart + PostToolUse(Bash) hooks, diffs `HEAD` against the last indexed commit, filters to supported extensions, content-hashes files, and re-parses only those with changed content.

## Scope

Implements `docs/superpowers/plans/2026-03-27-auto-reindex.md`:

- **Cache extension**: `CacheEntry.contentHash` (SHA-256, 16 hex chars) — enables content-based skip instead of mtime-only
- **`src/capture/incremental-reindexer.ts`**: core diff + filter + reparse loop
- **SessionStart hook**: runs incremental reindex after the existing context build
- **PostToolUse(Bash) hook**: replaces the "stale context" warning with actual reindex when git HEAD moves
- **`last_head.txt`**: written during full `/sia-learn` runs so incremental has a baseline to diff from
- **Backward compat**: `.sia-graph/last-indexed-commit` also written when the directory already exists
- **Tests**: 5 new unit tests for `getChangedFiles`, `filterSupportedFiles`, `computeContentHash`

## Stats

- **4 commits** on top of main (plus 2 pre-existing from earlier auto-reindex work merged with transformer stack)
- **Tests:** 1973/1973 pass (up from 1968; +5 new)
- **TypeScript:** clean (`tsc --noEmit` exits 0)
- **Integration test** (bun): 4/4 pass

## Security

All git commands use `execFileSync` with array args — no shell interpolation, no injection vectors.

## Follow-up plans

Nous (`docs/superpowers/plans/2026-04-03-nous.md`) — cognitive layer with always-active monitoring hooks. Benefits from auto-reindex being in place so Nous reads from a fresh graph state.

## Test plan

- [x] `npx vitest run` — 1973/1973 pass
- [x] `npx tsc --noEmit` — clean
- [x] `bun test tests/capture/incremental-reindex-integration.test.ts` — 4/4 pass
- [ ] Manual end-to-end on real branch switch (Task 7, deferred)

## Known CI note

The repo's lint CI job has been red on main since April 4 due to pre-existing biome tech debt (175 errors across 533 files, unrelated to this PR). Admin merge recommended (same as PR #53) until a separate lint cleanup PR lands.