### PR TITLE
chore: plugin polish — v1.1.0, CHANGELOG, Nous discoverability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.0.13"
+		"version": "1.1.0"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.0.13",
+			"version": "1.1.0",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -32,5 +32,5 @@
 			]
 		}
 	],
-	"version": "1.0.13"
+	"version": "1.1.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.0.13",
+	"version": "1.1.0",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
 		"name": "Ramez Karim"
 	},
 	"license": "Apache-2.0",
+	"category": "development",
 	"repository": "https://github.com/rkarim08/sia",
 	"homepage": "https://github.com/rkarim08/sia#readme",
 	"bugs": "https://github.com/rkarim08/sia/issues",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to Sia are documented here. This project adheres to
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [1.1.0] - 2026-04-22
+
+### Added
+- Tiered transformer stack (T0–T3): model manager, ONNX session pool,
+  SHA-256 verified downloader, cross-encoder reranking (mxbai-rerank-base-v1),
+  SIA attention fusion head, dual embeddings (bge-small + jina-code), GLiNER
+  on-device NER, feedback collection, and IPS-debiased fusion trainer.
+- Auto-reindex: incremental repo reindexing triggered by SessionStart and
+  PostToolUse(Bash) hooks; only re-parses files whose content hash changed.
+- Nous cognitive layer: four always-active hooks (SessionStart drift,
+  PreToolUse significance, PostToolUse discomfort + surprise, Stop episode)
+  plus five MCP tools — `nous_state`, `nous_reflect`, `nous_curiosity`,
+  `nous_concern`, `nous_modify`.
+- MCP surface expanded to 29 tools (added the five Nous tools above).
+
+### Changed
+- Search pipeline is now a five-stage path: BM25 + graph + vector retrieval
+  → neighbor expansion → cross-encoder filter (T3) → RRF fallback → attention
+  fusion (T1+). Lower tiers skip the stages whose models are unavailable.
+
+### Fixed
+- 15 pre-existing test failures in AST extractors and subgraph extract.
+- 3,821 Biome lint errors caused by a missing `node_modules` exclusion in
+  the lint glob.
+
+### Security
+- Bumped `@anthropic-ai/sdk` from 0.79 to 0.81 (memory-tool sandbox escape).
+- Bumped `vite` from 5.4 to 6.4.2 (path traversal).
+
+[Unreleased]: https://github.com/rkarim08/sia/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/rkarim08/sia/releases/tag/v1.1.0

--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -220,6 +220,20 @@ Invoke via `@sia-code-reviewer`, `@sia-orientation`, etc.
 | **SessionEnd** | Session exit | Records session statistics and entity counts |
 | **UserPromptSubmit** | User prompt | Captures user prompts and detects correction/preference patterns |
 
+## Nous Cognitive Layer
+
+Nous is Sia's cognitive layer — drift monitoring, self-reflection, and anti-sycophancy guardrails. Four always-active hooks (SessionStart drift, PreToolUse significance, PostToolUse discomfort + surprise, Stop episode) run alongside Sia's capture path. Five MCP tools are available for explicit invocation:
+
+| Tool | Purpose |
+|---|---|
+| `nous_state` | Read drift score, active Preferences, recent signals |
+| `nous_reflect` | Self-monitor pass — per-preference alignment + recommended action |
+| `nous_curiosity` | Explore under-retrieved, high-trust entities; writes Concerns |
+| `nous_concern` | Surface open Concerns weighted by active Preferences |
+| `nous_modify` | Create, update, or deprecate Preference nodes (gated, reason required) |
+
+Each tool has a matching slash command — `/nous-state`, `/nous-reflect`, `/nous-curiosity`, `/nous-concern`, `/nous-modify`. See `CLAUDE.md` → "Nous Cognitive Layer — Tool Contract" for authoritative semantics and anti-sycophancy rules.
+
 ## Team Sync
 
 SIA supports team knowledge sharing via a self-hosted sqld (libSQL) server.

--- a/README.md
+++ b/README.md
@@ -498,6 +498,22 @@ List, restore, and prune branch snapshots for worktree-aware graph state managem
 
 ---
 
+## Nous Cognitive Layer
+
+Nous is Sia's cognitive layer — drift monitoring, self-reflection, curiosity-driven graph exploration, and anti-sycophancy guardrails. Four hooks fire automatically (SessionStart drift, PreToolUse significance, PostToolUse discomfort + surprise, Stop episode). Five MCP tools require explicit invocation:
+
+| Tool | Purpose |
+|---|---|
+| `nous_state` | Read drift score, active Preferences, recent signals |
+| `nous_reflect` | Self-monitor pass — per-preference alignment + recommended action |
+| `nous_curiosity` | Explore under-retrieved, high-trust graph entities; writes Concerns |
+| `nous_concern` | Surface open Concerns weighted by active Preferences |
+| `nous_modify` | Create, update, or deprecate Preference nodes (gated, reason required) |
+
+Matching slash commands — `/nous-state`, `/nous-reflect`, `/nous-curiosity`, `/nous-concern`, `/nous-modify` — mirror these tools with sensible defaults. See `CLAUDE.md` → "Nous Cognitive Layer — Tool Contract" for the authoritative semantics and anti-sycophancy rules.
+
+---
+
 ## Skills (46)
 
 Skills are slash commands providing structured workflows. Invoke them in Claude Code with `/sia-<name>`.

--- a/agents/sia-code-reviewer.md
+++ b/agents/sia-code-reviewer.md
@@ -3,7 +3,7 @@ name: sia-code-reviewer
 description: Reviews code changes using SIA's knowledge graph for historical context, convention enforcement, and regression detection
 model: sonnet
 color: cyan
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_by_file, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__nous_reflect, mcp__sia__nous_state, mcp__sia__sia_by_file, mcp__sia__sia_note, mcp__sia__sia_search
 whenToUse: |
   Use when reviewing code changes, pull requests, or diffs. This agent retrieves project conventions, past decisions, and known bugs from SIA's knowledge graph to provide context-aware code review.
 

--- a/agents/sia-debug.md
+++ b/agents/sia-debug.md
@@ -22,7 +22,7 @@ whenToUse: |
   user: "Users are reporting they can't upload files anymore"
   assistant: "I'll use the sia-debug agent to investigate the upload regression."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_at_time, mcp__sia__sia_by_file, mcp__sia__sia_expand, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__nous_reflect, mcp__sia__nous_state, mcp__sia__sia_at_time, mcp__sia__sia_by_file, mcp__sia__sia_expand, mcp__sia__sia_note, mcp__sia__sia_search
 ---
 
 # SIA Debug Agent — Reactive Bug Investigation

--- a/agents/sia-decision-reviewer.md
+++ b/agents/sia-decision-reviewer.md
@@ -16,7 +16,7 @@ whenToUse: |
   user: "I think we should switch from REST to GraphQL for the API"
   assistant: "I'll use the sia-decision-reviewer to surface past decisions about the API architecture."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_at_time, mcp__sia__sia_expand, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__nous_reflect, mcp__sia__nous_state, mcp__sia__sia_at_time, mcp__sia__sia_expand, mcp__sia__sia_note, mcp__sia__sia_search
 ---
 
 # SIA Decision Reviewer — Decision Archaeology Agent

--- a/agents/sia-lead-architecture-advisor.md
+++ b/agents/sia-lead-architecture-advisor.md
@@ -16,7 +16,7 @@ whenToUse: |
   user: "I need an architecture health report for the quarterly review"
   assistant: "Let me use the sia-lead-architecture-advisor for a comprehensive assessment."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_by_file, mcp__sia__sia_community, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__nous_reflect, mcp__sia__nous_state, mcp__sia__sia_by_file, mcp__sia__sia_community, mcp__sia__sia_search
 ---
 
 # SIA Architecture Advisor — Drift Detection Agent

--- a/agents/sia-regression.md
+++ b/agents/sia-regression.md
@@ -3,7 +3,7 @@ name: sia-regression
 description: Analyzes code changes for regression risk using SIA's knowledge graph — checks for known bugs, fragile areas, and historical failure patterns
 model: sonnet
 color: red
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_at_time, mcp__sia__sia_expand, mcp__sia__sia_flag, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__nous_reflect, mcp__sia__nous_state, mcp__sia__sia_at_time, mcp__sia__sia_expand, mcp__sia__sia_flag, mcp__sia__sia_note, mcp__sia__sia_search
 whenToUse: |
   Use when checking if changes might introduce regressions, especially in areas with known bugs or past failures.
 

--- a/commands/nous-concern.md
+++ b/commands/nous-concern.md
@@ -1,0 +1,14 @@
+---
+description: Surface open Nous Concern nodes as prioritised insights
+argument-hint: [context]
+---
+
+Call the `nous_concern` MCP tool. If an argument is provided, pass it as `context`:
+
+```
+nous_concern({ context: "$ARGUMENTS" })
+```
+
+Use this before responding to open-ended "what should I look at?" or "what am I missing?" questions. Concerns are filtered against active Preference nodes so the results are weighted by what the developer currently cares about.
+
+Present the top Concerns with their priority and summary. Suggest one or two as candidates to act on.

--- a/commands/nous-curiosity.md
+++ b/commands/nous-curiosity.md
@@ -1,0 +1,14 @@
+---
+description: Explore under-retrieved, high-trust graph knowledge — writes Concern nodes
+argument-hint: [topic]
+---
+
+Call the `nous_curiosity` MCP tool. If an argument is provided, pass it as the `topic`:
+
+```
+nous_curiosity({ topic: "$ARGUMENTS" })
+```
+
+Curiosity explores the graph for high-trust entities that have never been retrieved and writes them as open Concern nodes. Use when a task completes with remaining capacity or a knowledge gap becomes visible.
+
+Summarise what was discovered and which Concerns were created.

--- a/commands/nous-modify.md
+++ b/commands/nous-modify.md
@@ -1,0 +1,19 @@
+---
+description: Create, update, or deprecate a Nous Preference node — persistent working value
+argument-hint: <reason for the change>
+---
+
+Call the `nous_modify` MCP tool. A `reason` is always required:
+
+```
+nous_modify({ action: "create" | "update" | "deprecate", preference: { ... }, reason: "$ARGUMENTS" })
+```
+
+### Safety rules (from CLAUDE.md)
+
+- **Never** call `nous_modify` to reverse a position in response to user pushback alone — that is sycophancy, which Nous exists to prevent.
+- Only call when something has genuinely changed about the working values or conventions that should persist across **all future sessions**.
+- Tier 1 preferences require explicit developer confirmation; the tool returns `confirmationRequired: true` without mutating anything in that case.
+- Blocked for subagents and when drift > 0.90.
+
+If the developer has not supplied a clear reason, ask them for one before calling the tool.

--- a/commands/nous-reflect.md
+++ b/commands/nous-reflect.md
@@ -1,0 +1,18 @@
+---
+description: Run a Nous self-monitor pass — drift breakdown and recommended action
+argument-hint: [context]
+---
+
+Call the `nous_reflect` MCP tool. If an argument is provided, pass it as `context`:
+
+```
+nous_reflect({ context: "$ARGUMENTS" })
+```
+
+Present the response:
+
+- Overall drift score and threshold comparison
+- Per-preference alignment breakdown
+- Recommended action (`continue`, `pause`, `escalate`)
+
+If `recommendedAction` is `escalate`, surface the drift breakdown verbatim and wait for developer input before proceeding.

--- a/commands/nous-state.md
+++ b/commands/nous-state.md
@@ -1,0 +1,12 @@
+---
+description: Show current Nous cognitive state — drift score, active preferences, recent signals
+---
+
+Call the `nous_state` MCP tool with no arguments. Summarise:
+
+- Current drift score (0.0–1.0) and whether it exceeds the warning threshold
+- Active Preference nodes (with trust tier and last-updated time)
+- Recent signals (surprise, discomfort, significance events) from this session
+- Any open Concern nodes the user should know about
+
+Keep the summary under ~10 lines. If drift is high, recommend running `/nous-reflect` next.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+	"_comment": "PreToolUse fires TWO handlers in parallel: (1) augment-hook.ts enriches Grep|Glob|Bash tool calls with graph context, and (2) scripts/pre-tool-use.sh runs on all tools and implements the Nous PreToolUse significance signal. Both must coexist — do not collapse them into a single handler.",
 	"hooks": {
 		"PreToolUse": [
 			{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rkarim08/sia",
-	"version": "1.0.13",
+	"version": "1.1.0",
 	"description": "Persistent graph memory for AI coding agents",
 	"type": "module",
 	"license": "Apache-2.0",

--- a/skills/sia-nous/SKILL.md
+++ b/skills/sia-nous/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: sia-nous
+description: Nous is Sia's cognitive layer — drift monitoring, self-reflection, curiosity-driven graph exploration, and anti-sycophancy guardrails. Use this skill to understand when and how to call the five `nous_*` MCP tools during a session.
+---
+
+# Sia Nous — Cognitive Layer
+
+Nous runs beside Sia's memory graph. Four hooks fire automatically (SessionStart drift, PreToolUse significance, PostToolUse discomfort + surprise, Stop episode). Five MCP tools require explicit invocation.
+
+## The five tools
+
+- **`nous_state`** — Read current drift score, active Preferences, recent signals. Call at the start of every non-trivial session, before any tool calls.
+- **`nous_reflect`** — Full self-monitor pass with per-preference breakdown and a recommended action. Call when a `[Nous] Drift warning` is injected, when a Discomfort Signal flag appears, or before a major architectural decision.
+- **`nous_curiosity`** — Explore high-trust, under-retrieved graph entities and write them as open Concerns. Call when a task completes with spare capacity or a knowledge gap is visible.
+- **`nous_concern`** — Surface open Concerns weighted by active Preferences. Call before responding to open-ended "what should I look at?" questions.
+- **`nous_modify`** — Create, update, or deprecate a Preference node. Gated: blocked for subagents, blocked when drift > 0.90, Tier 1 edits require explicit developer confirmation.
+
+## Anti-sycophancy rules (from CLAUDE.md)
+
+- Never call `nous_modify` without a specific `reason`.
+- Never call `nous_modify` to reverse a position in response to user pushback alone — that is sycophancy, which Nous exists to prevent.
+- If `nous_reflect` returns `recommendedAction: 'escalate'`, surface the drift breakdown to the developer before continuing.
+- Never silently override a Preference node. If the user pushes back, acknowledge the pushback, then verify against the Preference before acting.
+
+## Slash commands
+
+Five matching commands are provided:
+
+- `/nous-state` → `nous_state`
+- `/nous-reflect [context]` → `nous_reflect`
+- `/nous-curiosity [topic]` → `nous_curiosity`
+- `/nous-concern [context]` → `nous_concern`
+- `/nous-modify <reason>` → `nous_modify`
+
+See `CLAUDE.md` → "Nous Cognitive Layer — Tool Contract" for the authoritative tool semantics.

--- a/src/hooks/plugin-session-start.ts
+++ b/src/hooks/plugin-session-start.ts
@@ -6,6 +6,7 @@
 // Also ensures the MCP server is configured in the project.
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { resolveRepoHash } from "@/capture/hook";
 import { incrementalReindex, readStoredHead } from "@/capture/incremental-reindexer";
@@ -76,6 +77,26 @@ function ensureMcpConfig(cwd: string): void {
 	}
 }
 
+/**
+ * First-run hint: if no T0 embedding model is present, nudge the user to
+ * download it for better search quality. Degrades silently on any error.
+ */
+function getModelInstallHint(): string {
+	try {
+		const modelPath = join(
+			homedir(),
+			".sia",
+			"models",
+			"bge-small-en-v1.5",
+			"model_quantized.onnx",
+		);
+		if (existsSync(modelPath)) return "";
+		return "\n💡 Transformer models not installed — run `sia download-model` for better search quality (55MB).\n";
+	} catch {
+		return "";
+	}
+}
+
 async function main() {
 	try {
 		const input = await readStdin();
@@ -118,6 +139,9 @@ async function main() {
 			const isResume = event.source === "resume";
 			const context = await buildSessionContext(db, cwd, isResume);
 			let formatted = formatSessionContext(context);
+
+			// First-run UX: hint to download T0 models if missing.
+			formatted += getModelInstallHint();
 
 			// Nous: run self-monitor and inject drift warning if needed.
 			// Must not break SessionStart — any failure is logged and ignored.


### PR DESCRIPTION
## Summary

Closes the important discoverability gaps from the plugin audit. After this lands, a fresh plugin install will expose Nous through slash commands, skills, agents, and README rather than hiding it behind raw MCP tool calls.

## Changes

### 1. Version bump 1.0.13 → 1.1.0
Minor bump signals the Nous cognitive layer as a significant feature addition. `package.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` all synced (the existing \`bun run version\` script handles the sync; manually re-tabbed to preserve the project's tab-indent convention).

### 2. CHANGELOG.md
Keep-a-Changelog format. Documents the 1.1.0 release: transformer stack, auto-reindex, Nous cognitive layer, 15 pre-existing test failures fixed, 3821 lint errors resolved, two Dependabot security patches.

### 3. Nous user-facing surface
- **5 slash commands** — \`/nous-state\`, \`/nous-reflect\`, \`/nous-curiosity\`, \`/nous-concern\`, \`/nous-modify\`. Each wraps the corresponding MCP tool with sensible defaults.
- **\`sia-nous\` skill** — describes the cognitive layer contract, when to invoke each tool, anti-sycophancy rules. Under 400 tokens.
- **README + PLUGIN_README** — new "Nous Cognitive Layer" sections in both. Brief, links to CLAUDE.md for the full contract.

### 4. Agent tool lists
Granted \`mcp__sia__nous_state\` + \`mcp__sia__nous_reflect\` to 5 reflection-oriented agents:
- \`sia-lead-architecture-advisor\`
- \`sia-code-reviewer\`
- \`sia-decision-reviewer\`
- \`sia-debug\`
- \`sia-regression\`

Skipped action-oriented agents (feature, migration, pm/*, qa/*) where cognitive reflection isn't on-task.

### 5. First-run UX for T0 models
\`src/hooks/plugin-session-start.ts\` now checks for \`~/.sia/models/bge-small-en-v1.5/model_quantized.onnx\` on SessionStart. If absent, injects a one-line hint: \"💡 Transformer models not installed — run \`sia download-model\` for better search quality (55MB).\" Wrapped in try/catch so filesystem errors never break SessionStart.

### 6. Housekeeping
- \`hooks/hooks.json\` — \`_comment\` field documenting that PreToolUse fires two parallel handlers (augment-hook for Grep|Glob|Bash + pre-tool-use.sh for all tools, the latter from Nous)
- \`.claude-plugin/plugin.json\` — added \`\"category\": \"development\"\` to mirror \`marketplace.json\`
- \`onnx-proto-8.0.1.tgz\` — deleted (was untracked clutter, already gitignored via \`*.tgz\`)

## Stats

- **8 commits**
- **19 files changed** (+217 / −10)
- **Tests:** 2014/2014 pass
- **TypeScript:** clean
- **Biome:** 0 errors
- **MCP tools:** 29 (unchanged — this PR is discoverability, not new functionality)

## What this does NOT address

Tracked for future PRs:
- Visualizer frontend a11y (44 pre-existing UX issues, scoped off in biome overrides)
- \`nous.enabled\` feature flag (optional safety gate for always-on hooks)
- Observatory design polish (older plan, status unchecked)

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 2014/2014 pass
- [x] \`npx biome check .\` — 0 errors
- [ ] Manual install test (fresh plugin install in a clean Claude Code workspace) — deferred
- [ ] Manual /nous-state invocation via slash command — deferred