### PR TITLE
chore(release): 1.1.1 — observatory design polish

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.0"
+		"version": "1.1.1"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -32,5 +32,5 @@
 			]
 		}
 	],
-	"version": "1.1.0"
+	"version": "1.1.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-04-21
+
+### Changed
+- Observatory (visualizer) design polish — eight coordinated UI refinements
+  bringing the graph view in line with the product's "code observatory"
+  vision:
+  - Ambient gradient orbs and a radial vignette replace the static dot grid,
+    giving the canvas a living, atmospheric feel.
+  - Staggered entrance animations (`fadeInDown`, `fadeInUp`, `fadeIn`) on
+    the header, sidebar, canvas, and inspector, plus a pulsing SIA wordmark
+    while the graph builds.
+  - Node glow halos on hover (radial gradient + soft ring) and a
+    selected-node pulse ring driven by a `requestAnimationFrame` loop that
+    breathes the size factor between 0.85× and 1.15×.
+  - Contextual cursor that swaps between `crosshair` (panning) and
+    `pointer` (over a node) based on the hover target.
+  - Redesigned bottom status bar with node / edge / visible counts,
+    active-mode badges (`BLAST`, `FOLDER`, `HULLS`), current layout, and a
+    `?` shortcuts hint.
+  - Command palette now groups results by node type with uppercase category
+    headers and shows a "Quick actions" empty state when the query is blank.
+  - Inspector tab bar (`code` / `entities` / `deps`) replacing the single
+    stacked scroll, with auto-switch to `entities` for non-file nodes.
+  - Node size legend (fn / file / class / decision) in the bottom-left when
+    no node is selected.
+
 ## [1.1.0] - 2026-04-22
 
 ### Added
@@ -35,5 +61,6 @@ All notable changes to Sia are documented here. This project adheres to
 - Bumped `@anthropic-ai/sdk` from 0.79 to 0.81 (memory-tool sandbox escape).
 - Bumped `vite` from 5.4 to 6.4.2 (path traversal).
 
-[Unreleased]: https://github.com/rkarim08/sia/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/rkarim08/sia/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/rkarim08/sia/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/rkarim08/sia/releases/tag/v1.1.0


### PR DESCRIPTION
## Summary

Release 1.1.1 capturing the eight Observatory (visualizer) UI polish refinements already shipped in `src/visualization/frontend/`:

- **Ambient gradient orbs** + radial vignette replacing the static dot grid (living background).
- **Staggered entrance animations** (`fadeInDown` / `fadeInUp` / `fadeIn`) for header, sidebar, canvas, inspector — plus a pulsing SIA wordmark while the graph builds.
- **Node glow halos** on hover (radial gradient + soft ring) and a **selected-node pulse ring** driven by `requestAnimationFrame` (size breathes 0.85× → 1.15×).
- **Contextual cursor** — `crosshair` for panning, `pointer` on node hover.
- **Redesigned status bar** — node / edge / visible counts, active-mode badges (`BLAST`, `FOLDER`, `HULLS`), current layout, `?` shortcut hint.
- **Command palette** — grouped by node type with uppercase category headers + "Quick actions" empty state.
- **Inspector tab bar** — `code` / `entities` / `deps`, auto-switches to `entities` for non-file nodes.
- **Node size legend** — fn / file / class / decision dots in the bottom-left when nothing is selected.

Files bumped:
- `CHANGELOG.md` — new `[1.1.1] 2026-04-21` entry under "Changed".
- `.claude-plugin/plugin.json` — `1.1.0` → `1.1.1`.
- `.claude-plugin/marketplace.json` — metadata + plugin entry + top-level all bumped to `1.1.1`.

All eight visual changes themselves landed in prior `style(viz)`/`feat(viz)` commits on main (e.g. `b03ed9e`, `6e4f44e`, `994e67e`, `a66dc00`, `a8b3699`). This PR is the release-note / version-bump cap for that workstream.

## Test plan

- [x] `bunx tsc --noEmit` at repo root — clean.
- [x] `bunx tsc --noEmit` in `src/visualization/frontend/` — clean.
- [x] `bunx @biomejs/biome check .claude-plugin/ src/visualization/` — clean.
- [x] `bun test tests/unit/visualization/` — 20/20 pass.
- [x] `cd src/visualization/frontend && bun run build` — builds.
- [x] Manual spot-check of each of the eight polish items against the plan spec (`docs/superpowers/plans/2026-03-26-observatory-design-polish.md`) — all present in code.

## Notes

- Pre-existing test failures outside the visualizer scope (AST / tree-sitter `.scm` query files not present on disk) were not introduced by this branch and remain pre-existing.
- Biome a11y overrides for `src/visualization/frontend/**` left untouched per instructions.