### PR TITLE
feat(nous): enabled flag defense-in-depth + 1.1.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.0"
+		"version": "1.1.1"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -32,5 +32,5 @@
 			]
 		}
 	],
-	"version": "1.1.0"
+	"version": "1.1.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-04-21
+
+### Added
+- Defense-in-depth gates for `config.nous.enabled` in the `self-monitor` and
+  `episode-writer` inner modules — direct callers (tests, MCP tools) now match
+  the plugin hook layer's always-gated behavior.
+- README section describing how to disable Nous via `nous.enabled = false`.
+
+### Changed
+- Observatory (visualizer) design polish — eight coordinated UI refinements
+  bringing the graph view in line with the product's "code observatory"
+  vision:
+  - Ambient gradient orbs and a radial vignette replace the static dot grid,
+    giving the canvas a living, atmospheric feel.
+  - Staggered entrance animations (`fadeInDown`, `fadeInUp`, `fadeIn`) on
+    the header, sidebar, canvas, and inspector, plus a pulsing SIA wordmark
+    while the graph builds.
+  - Node glow halos on hover (radial gradient + soft ring) and a
+    selected-node pulse ring driven by a `requestAnimationFrame` loop that
+    breathes the size factor between 0.85× and 1.15×.
+  - Contextual cursor that swaps between `crosshair` (panning) and
+    `pointer` (over a node) based on the hover target.
+  - Redesigned bottom status bar with node / edge / visible counts,
+    active-mode badges (`BLAST`, `FOLDER`, `HULLS`), current layout, and a
+    `?` shortcuts hint.
+  - Command palette now groups results by node type with uppercase category
+    headers and shows a "Quick actions" empty state when the query is blank.
+  - Inspector tab bar (`code` / `entities` / `deps`) replacing the single
+    stacked scroll, with auto-switch to `entities` for non-file nodes.
+  - Node size legend (fn / file / class / decision) in the bottom-left when
+    no node is selected.
+
+### Fixed
+- Two `toBeUndefined()` assertions against `bun:sqlite` `.get()` results were
+  racing against the driver's `null`-for-no-row convention. Normalized both
+  tests (plus the new disabled-path tests) to `toBeNull()`.
+
 ## [1.1.0] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -512,6 +512,8 @@ Nous is Sia's cognitive layer — drift monitoring, self-reflection, curiosity-d
 
 Matching slash commands — `/nous-state`, `/nous-reflect`, `/nous-curiosity`, `/nous-concern`, `/nous-modify` — mirror these tools with sensible defaults. See `CLAUDE.md` → "Nous Cognitive Layer — Tool Contract" for the authoritative semantics and anti-sycophancy rules.
 
+**Disabling Nous.** Set `nous.enabled = false` in your Sia config (defaults to `true`). When disabled, all four hooks become no-ops — no session rows, no signals, no episodes — and the MCP tools remain callable but operate against an empty working memory. Useful for debugging, tightly-scoped agent sessions, or users who prefer retrieval-only Sia.
+
 ---
 
 ## Skills (46)

--- a/src/nous/episode-writer.ts
+++ b/src/nous/episode-writer.ts
@@ -14,8 +14,10 @@ import { appendHistory, deleteSession, getSession } from "./working-memory";
 export async function writeEpisode(
 	db: SiaDb,
 	sessionId: string,
-	_config: NousConfig = DEFAULT_NOUS_CONFIG,
+	config: NousConfig = DEFAULT_NOUS_CONFIG,
 ): Promise<void> {
+	if (!config.enabled) return;
+
 	const session = getSession(db, sessionId);
 	if (!session) return;
 

--- a/src/nous/self-monitor.ts
+++ b/src/nous/self-monitor.ts
@@ -39,6 +39,18 @@ export async function runSessionStart(
 ): Promise<SessionStartResult> {
 	const now = Math.floor(Date.now() / 1000);
 
+	if (!config.enabled) {
+		const session: NousSession = {
+			session_id: input.session_id,
+			parent_session_id: null,
+			session_type: "primary",
+			state: { ...DEFAULT_SESSION_STATE, sessionStartedAt: now },
+			created_at: now,
+			updated_at: now,
+		};
+		return { session, driftWarning: null, modifyBlocked: false };
+	}
+
 	cleanStaleSessions(db);
 
 	// First-run Preference seed — idempotent, no-op after first insert.

--- a/tests/unit/nous/episode-writer.test.ts
+++ b/tests/unit/nous/episode-writer.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { SiaDb } from "@/graph/db-interface";
 import { openGraphDb } from "@/graph/semantic-db";
 import { writeEpisode } from "@/nous/episode-writer";
-import { DEFAULT_SESSION_STATE } from "@/nous/types";
+import { DEFAULT_NOUS_CONFIG, DEFAULT_SESSION_STATE } from "@/nous/types";
 import { getSession, upsertSession } from "@/nous/working-memory";
 
 function makeTmp() {
@@ -77,12 +77,37 @@ describe("episode-writer", () => {
 		const episode = raw
 			?.prepare("SELECT * FROM graph_nodes WHERE kind = 'Episode' AND captured_by_session_id = ?")
 			.get("ep-sess-2");
-		expect(episode).toBeUndefined();
+		expect(episode ?? null).toBeNull();
 	});
 
 	it("does nothing if session not found", async () => {
 		tmpDir = makeTmp();
 		db = openGraphDb("test-ep3", tmpDir);
 		await expect(writeEpisode(db, "nonexistent")).resolves.toBeUndefined();
+	});
+
+	it("is a no-op when config.enabled is false", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-ep-disabled", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+		upsertSession(db, {
+			session_id: "ep-off",
+			parent_session_id: null,
+			session_type: "primary",
+			state: { ...DEFAULT_SESSION_STATE, driftScore: 0.3, toolCallCount: 5 },
+			created_at: now,
+			updated_at: now,
+		});
+
+		await writeEpisode(db, "ep-off", { ...DEFAULT_NOUS_CONFIG, enabled: false });
+
+		// Session row is preserved (noop does not delete) and no Episode is written
+		expect(getSession(db, "ep-off")).not.toBeNull();
+		const raw = db.rawSqlite();
+		const episode = raw
+			?.prepare("SELECT * FROM graph_nodes WHERE kind = 'Episode' AND captured_by_session_id = ?")
+			.get("ep-off");
+		expect(episode ?? null).toBeNull();
 	});
 });

--- a/tests/unit/nous/phase1-integration.test.ts
+++ b/tests/unit/nous/phase1-integration.test.ts
@@ -127,6 +127,6 @@ describe("nous Phase 1 integration", () => {
 		const episode = raw
 			.prepare("SELECT * FROM graph_nodes WHERE kind = 'Episode' AND captured_by_session_id = ?")
 			.get("subagent-1");
-		expect(episode).toBeUndefined();
+		expect(episode ?? null).toBeNull();
 	});
 });

--- a/tests/unit/nous/self-monitor.test.ts
+++ b/tests/unit/nous/self-monitor.test.ts
@@ -6,7 +6,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { SiaDb } from "@/graph/db-interface";
 import { openGraphDb } from "@/graph/semantic-db";
 import { runSessionStart } from "@/nous/self-monitor";
-import { appendHistory } from "@/nous/working-memory";
+import { DEFAULT_NOUS_CONFIG } from "@/nous/types";
+import { appendHistory, getSession } from "@/nous/working-memory";
 
 function makeTmp() {
 	return join(tmpdir(), `nous-sm-${randomUUID()}`);
@@ -52,6 +53,23 @@ describe("self-monitor", () => {
 		const result = await runSessionStart(db, { session_id: "sess-b", cwd: "/tmp" });
 		expect(result.session.state.driftScore).toBeGreaterThan(0.7);
 		expect(result.driftWarning).not.toBeNull();
+	});
+
+	it("is a no-op when config.enabled is false", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-sm-disabled", tmpDir);
+
+		const result = await runSessionStart(
+			db,
+			{ session_id: "sess-off", cwd: "/tmp" },
+			{ ...DEFAULT_NOUS_CONFIG, enabled: false },
+		);
+
+		// Returns a noop session shape, does not touch the DB
+		expect(result.session.session_id).toBe("sess-off");
+		expect(result.driftWarning).toBeNull();
+		expect(result.modifyBlocked).toBe(false);
+		expect(getSession(db, "sess-off")).toBeNull();
 	});
 
 	it("sets modifyBlocked when drift exceeds 0.90", async () => {


### PR DESCRIPTION
## Summary

- Adds `config.nous.enabled` early-return to `self-monitor.ts` and `episode-writer.ts` — the two inner Nous modules that lacked the gate (significance-detector, discomfort-signal, surprise-router already had it). Direct callers (MCP tools, unit tests) now see the same always-gated behavior as the plugin hook layer.
- Documents `nous.enabled = false` as the opt-out in README.
- Bundles the release cap for the Observatory design polish that landed in earlier commits — the 8 UI refinements are enumerated under `[1.1.1]` in CHANGELOG (supersedes #60).
- Normalises three `toBeUndefined()` assertions to `toBeNull()` to match `bun:sqlite` `.get()`'s no-row convention.
- Bumps plugin + marketplace manifests 1.1.0 → 1.1.1.

## Test plan

- [x] `bun test tests/unit/nous/` — 25/25 pass (up from 24 before; phase1 subagent case now green)
- [x] `bun test tests/unit/nous/episode-writer.test.ts tests/unit/nous/self-monitor.test.ts` — 8/8 pass including the two new `enabled: false` no-op tests
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx @biomejs/biome check src/nous/ tests/unit/nous/ CHANGELOG.md README.md .claude-plugin/` — 17 files, 0 errors

Pre-existing failures in `tests/unit/ast/tree-sitter/queries/**` and a few model-registry tests using dotted property names in `toHaveProperty` exist on main and are unrelated to this PR.

## Supersedes

Closes #60 — Observatory polish PR was a release cap for work already on main; its CHANGELOG entry is folded into this PR so a single 1.1.1 release captures both the Nous gate and the Observatory polish documentation.