### PR TITLE
fix(viz): observatory a11y cleanup + remove biome overrides (v1.1.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.1"
+		"version": "1.1.2"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -32,5 +32,5 @@
 			]
 		}
 	],
-	"version": "1.1.1"
+	"version": "1.1.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-04-21
+
+### Fixed
+- Observatory (visualizer) accessibility cleanup — removed the blanket Biome
+  a11y override for `src/visualization/frontend/**` and fixed the 44
+  resulting violations across `App.tsx`, `GraphCanvas.tsx`, `Sidebar.tsx`,
+  `SearchOverlay.tsx`, `ShortcutsModal.tsx`, `CodeInspector.tsx`, and
+  `ContextMenu.tsx`:
+  - Converted `<div onClick>` patterns to semantic `<button type="button">`
+    where possible (search results, file tree entries, entity/edge rows,
+    modal backdrops, bookmark items), restoring keyboard accessibility and
+    screen-reader labeling.
+  - Added explicit `type="button"` to every unlabeled `<button>` to avoid
+    the default `"submit"` behavior in a React SPA.
+  - Added `role="presentation"` + `aria-hidden="true"` to decorative SVG
+    icons sitting next to labeled text.
+  - Used stable `item.label` keys in `ContextMenu` instead of array
+    indices.
+  - Restructured the Node Types sidebar row (previously nested an
+    interactive `<input>` and `<label>` inside a `<button>`, which is
+    invalid HTML) into a flex row with the color-swatch label and the
+    toggle button as siblings.
+  - Added `aria-label` / `aria-pressed` / `aria-expanded` on interactive
+    controls (close buttons, tab bars, layout mode toggles, folder tree).
+- No `// biome-ignore` suppressions were added — all violations fixed
+  structurally.
+
 ## [1.1.1] - 2026-04-21
 
 ### Added

--- a/biome.json
+++ b/biome.json
@@ -17,24 +17,6 @@
 			}
 		}
 	},
-	"overrides": [
-		{
-			"includes": ["src/visualization/frontend/**"],
-			"linter": {
-				"rules": {
-					"a11y": {
-						"noStaticElementInteractions": "off",
-						"useKeyWithClickEvents": "off",
-						"useButtonType": "off",
-						"noSvgWithoutTitle": "off"
-					},
-					"suspicious": {
-						"noArrayIndexKey": "off"
-					}
-				}
-			}
-		}
-	],
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab",

--- a/src/visualization/frontend/src/App.tsx
+++ b/src/visualization/frontend/src/App.tsx
@@ -267,6 +267,8 @@ export default function App() {
 					{/* Hamburger (mobile only) */}
 					{isMobile && (
 						<button
+							type="button"
+							aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
 							onClick={() => setSidebarOpen((prev) => !prev)}
 							style={{
 								background: "none",
@@ -347,6 +349,7 @@ export default function App() {
 
 					{/* Search trigger */}
 					<button
+						type="button"
 						onClick={() => setSearchOpen(true)}
 						style={{
 							display: "flex",
@@ -380,6 +383,8 @@ export default function App() {
 							stroke="currentColor"
 							strokeWidth="2.5"
 							strokeLinecap="round"
+							role="presentation"
+							aria-hidden="true"
 						>
 							<circle cx="11" cy="11" r="7" />
 							<line x1="21" y1="21" x2="16.65" y2="16.65" />
@@ -459,7 +464,9 @@ export default function App() {
 					</div>
 
 					{isMobile && sidebarOpen && (
-						<div
+						<button
+							type="button"
+							aria-label="Close sidebar"
 							onClick={() => setSidebarOpen(false)}
 							style={{
 								position: "fixed",
@@ -467,6 +474,9 @@ export default function App() {
 								top: 44,
 								background: "rgba(0,0,0,0.4)",
 								zIndex: 29,
+								border: "none",
+								padding: 0,
+								cursor: "pointer",
 							}}
 						/>
 					)}

--- a/src/visualization/frontend/src/components/CodeInspector.tsx
+++ b/src/visualization/frontend/src/components/CodeInspector.tsx
@@ -244,7 +244,9 @@ export default function CodeInspector({ node, onEntityClick, onClose }: Props) {
 		>
 			{/* Resize handle — left edge (desktop only) */}
 			{!isMobile && (
-				<div
+				<button
+					type="button"
+					aria-label="Resize inspector"
 					onMouseDown={startResize}
 					style={{
 						position: "absolute",
@@ -255,6 +257,8 @@ export default function CodeInspector({ node, onEntityClick, onClose }: Props) {
 						cursor: "col-resize",
 						zIndex: 10,
 						background: "transparent",
+						border: "none",
+						padding: 0,
 					}}
 					onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(59,130,246,0.35)")}
 					onMouseLeave={(e) => {
@@ -309,8 +313,10 @@ export default function CodeInspector({ node, onEntityClick, onClose }: Props) {
 					</span>
 				</div>
 				<button
+					type="button"
 					onClick={onClose}
 					title="Close inspector"
+					aria-label="Close inspector"
 					style={{
 						background: "none",
 						border: "none",
@@ -379,8 +385,10 @@ export default function CodeInspector({ node, onEntityClick, onClose }: Props) {
 			>
 				{(["code", "entities", "deps"] as const).map((tab) => (
 					<button
+						type="button"
 						key={tab}
 						onClick={() => setActiveTab(tab)}
+						aria-pressed={activeTab === tab}
 						style={{
 							flex: 1,
 							padding: "6px 0",
@@ -449,7 +457,8 @@ export default function CodeInspector({ node, onEntityClick, onClose }: Props) {
 							const entColor = NODE_COLORS[ent.nodeType as SiaNodeType] || "#888";
 							const isHovered = hoveredEntity === ent.id;
 							return (
-								<div
+								<button
+									type="button"
 									key={ent.id}
 									onClick={() => onEntityClick(ent.id)}
 									onMouseEnter={() => setHoveredEntity(ent.id)}
@@ -464,6 +473,11 @@ export default function CodeInspector({ node, onEntityClick, onClose }: Props) {
 										marginBottom: 1,
 										background: isHovered ? "rgba(255,255,255,0.05)" : "transparent",
 										transition: "background 0.12s",
+										border: "none",
+										width: "100%",
+										textAlign: "left",
+										font: "inherit",
+										color: "inherit",
 									}}
 								>
 									<span
@@ -501,7 +515,7 @@ export default function CodeInspector({ node, onEntityClick, onClose }: Props) {
 									>
 										{ent.nodeType}
 									</span>
-								</div>
+								</button>
 							);
 						})}
 					</div>
@@ -614,7 +628,8 @@ function EdgeRow({
 	const isLarge = typeof window !== "undefined" && window.innerWidth >= 2000;
 	const displayLabel = edge.label || resolveTargetLabel(edge.target, entities);
 	return (
-		<div
+		<button
+			type="button"
 			onClick={() => onEntityClick(edge.target)}
 			style={{
 				padding: "3px 8px",
@@ -627,11 +642,16 @@ function EdgeRow({
 				cursor: "pointer",
 				borderRadius: 4,
 				transition: "background 0.12s",
+				background: "transparent",
+				border: "none",
+				width: "100%",
+				textAlign: "left",
+				display: "block",
 			}}
 			onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.05)")}
 			onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
 		>
 			{displayLabel}
-		</div>
+		</button>
 	);
 }

--- a/src/visualization/frontend/src/components/ContextMenu.tsx
+++ b/src/visualization/frontend/src/components/ContextMenu.tsx
@@ -45,6 +45,7 @@ export default function ContextMenu({ x, y, items, onClose }: Props) {
 	return (
 		<div
 			ref={menuRef}
+			role="menu"
 			style={{
 				position: "fixed",
 				left: adjustedX,
@@ -62,7 +63,7 @@ export default function ContextMenu({ x, y, items, onClose }: Props) {
 			onContextMenu={(e) => e.preventDefault()}
 		>
 			{items.map((item, i) => (
-				<div key={i}>
+				<div key={item.label}>
 					{item.separator && i > 0 && (
 						<div
 							style={{
@@ -73,6 +74,8 @@ export default function ContextMenu({ x, y, items, onClose }: Props) {
 						/>
 					)}
 					<button
+						type="button"
+						role="menuitem"
 						onClick={() => {
 							item.onClick();
 							onClose();

--- a/src/visualization/frontend/src/components/GraphCanvas.tsx
+++ b/src/visualization/frontend/src/components/GraphCanvas.tsx
@@ -898,29 +898,36 @@ const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(
 									display: "flex",
 									alignItems: "center",
 									padding: "6px 10px",
-									cursor: "pointer",
 									fontSize: 12,
 									color: "#c8d0e0",
 									gap: 6,
 								}}
-								onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(59,130,246,0.12)")}
-								onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-								onClick={() => {
-									setCameraState(b.cameraState);
-									setShowBookmarks(false);
-								}}
 							>
-								<span
+								<button
+									type="button"
+									onClick={() => {
+										setCameraState(b.cameraState);
+										setShowBookmarks(false);
+									}}
 									style={{
 										flex: 1,
 										overflow: "hidden",
 										textOverflow: "ellipsis",
 										whiteSpace: "nowrap",
+										background: "transparent",
+										border: "none",
+										color: "inherit",
+										font: "inherit",
+										cursor: "pointer",
+										textAlign: "left",
+										padding: 0,
 									}}
 								>
 									{b.name}
-								</span>
+								</button>
 								<button
+									type="button"
+									aria-label={`Delete ${b.name}`}
 									onClick={(e) => {
 										e.stopPropagation();
 										deleteBookmark(b.id);
@@ -967,6 +974,7 @@ const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(
 					>
 						<span>Path: {pathNodes.size} nodes</span>
 						<button
+							type="button"
 							onClick={onClearPath}
 							style={{
 								background: "rgba(249,115,22,0.2)",
@@ -996,8 +1004,11 @@ const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(
 				>
 					{(["force", "tree", "radial"] as LayoutMode[]).map((mode) => (
 						<button
+							type="button"
 							key={mode}
 							onClick={() => onLayoutModeChange(mode)}
+							aria-pressed={layoutMode === mode}
+							aria-label={`${mode} layout`}
 							style={{
 								width: Math.round(28 * lgScale),
 								height: Math.round(28 * lgScale),
@@ -1289,8 +1300,11 @@ function ZoomBtn({
 
 	return (
 		<button
+			type="button"
 			onClick={onClick}
 			title={title}
+			aria-label={title}
+			aria-pressed={active}
 			onMouseEnter={() => setHovered(true)}
 			onMouseLeave={() => {
 				setHovered(false);

--- a/src/visualization/frontend/src/components/SearchOverlay.tsx
+++ b/src/visualization/frontend/src/components/SearchOverlay.tsx
@@ -95,22 +95,36 @@ export default function SearchOverlay({ onSelect, onClose }: Props) {
 
 	return (
 		<div
-			onClick={onClose}
 			style={{
 				position: "fixed",
 				inset: 0,
 				zIndex: 1000,
-				background: "rgba(0, 0, 0, 0.5)",
-				backdropFilter: "blur(20px)",
 				display: "flex",
 				alignItems: "flex-start",
 				justifyContent: "center",
 				paddingTop: "15vh",
 			}}
 		>
-			<div
-				onClick={(e) => e.stopPropagation()}
+			<button
+				type="button"
+				aria-label="Close search"
+				onClick={onClose}
 				style={{
+					position: "fixed",
+					inset: 0,
+					background: "rgba(0, 0, 0, 0.5)",
+					backdropFilter: "blur(20px)",
+					border: "none",
+					padding: 0,
+					cursor: "default",
+				}}
+			/>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-label="Search"
+				style={{
+					position: "relative",
 					width: isLarge ? 680 : 520,
 					maxWidth: "90vw",
 					background: "rgba(14,14,28,0.9)",
@@ -140,6 +154,8 @@ export default function SearchOverlay({ onSelect, onClose }: Props) {
 						strokeWidth="2"
 						strokeLinecap="round"
 						strokeLinejoin="round"
+						role="presentation"
+						aria-hidden="true"
 					>
 						<circle cx="11" cy="11" r="8" />
 						<line x1="21" y1="21" x2="16.65" y2="16.65" />
@@ -214,7 +230,8 @@ export default function SearchOverlay({ onSelect, onClose }: Props) {
 									const isSelected = globalIndex === selectedIndex;
 									const dotColor = NODE_COLORS[r.type as SiaNodeType] || "#666";
 									return (
-										<div
+										<button
+											type="button"
 											key={r.id}
 											onClick={() => handleResultClick(r.id)}
 											onMouseEnter={() => setSelectedIndex(globalIndex)}
@@ -226,6 +243,11 @@ export default function SearchOverlay({ onSelect, onClose }: Props) {
 												cursor: "pointer",
 												background: isSelected ? "rgba(59,130,246,0.12)" : "transparent",
 												transition: "background 0.1s",
+												border: "none",
+												width: "100%",
+												textAlign: "left",
+												color: "inherit",
+												font: "inherit",
 											}}
 										>
 											<span
@@ -277,7 +299,7 @@ export default function SearchOverlay({ onSelect, onClose }: Props) {
 											>
 												{r.type}
 											</span>
-										</div>
+										</button>
 									);
 								})}
 							</div>

--- a/src/visualization/frontend/src/components/ShortcutsModal.tsx
+++ b/src/visualization/frontend/src/components/ShortcutsModal.tsx
@@ -48,21 +48,35 @@ export default function ShortcutsModal({ onClose }: Props) {
 
 	return (
 		<div
-			onClick={onClose}
 			style={{
 				position: "fixed",
 				inset: 0,
 				zIndex: 1000,
-				background: "rgba(0,0,0,0.4)",
-				backdropFilter: "blur(8px)",
 				display: "flex",
 				alignItems: "center",
 				justifyContent: "center",
 			}}
 		>
-			<div
-				onClick={(e) => e.stopPropagation()}
+			<button
+				type="button"
+				aria-label="Close shortcuts"
+				onClick={onClose}
 				style={{
+					position: "fixed",
+					inset: 0,
+					background: "rgba(0,0,0,0.4)",
+					backdropFilter: "blur(8px)",
+					border: "none",
+					padding: 0,
+					cursor: "pointer",
+				}}
+			/>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-label="Keyboard shortcuts"
+				style={{
+					position: "relative",
 					width: isLarge ? 640 : 480,
 					maxWidth: "90vw",
 					background: "rgba(14,14,28,0.92)",

--- a/src/visualization/frontend/src/components/Sidebar.tsx
+++ b/src/visualization/frontend/src/components/Sidebar.tsx
@@ -124,6 +124,8 @@ export default function Sidebar({
 						strokeWidth="2"
 						strokeLinecap="round"
 						strokeLinejoin="round"
+						role="presentation"
+						aria-hidden="true"
 						style={{ position: "absolute", left: 8, top: "50%", transform: "translateY(-50%)" }}
 					>
 						<circle cx="11" cy="11" r="8" />
@@ -154,7 +156,8 @@ export default function Sidebar({
 				{searchResults.length > 0 && (
 					<div style={{ marginTop: 8, maxHeight: 180, overflow: "auto" }}>
 						{searchResults.map((r) => (
-							<div
+							<button
+								type="button"
 								key={r.id}
 								onClick={() => {
 									feedback?.recordSearchClick(r.id, searchQuery);
@@ -169,6 +172,11 @@ export default function Sidebar({
 									alignItems: "center",
 									gap: 7,
 									color: "#c8d0e0",
+									background: "transparent",
+									border: "none",
+									width: "100%",
+									textAlign: "left",
+									font: "inherit",
 								}}
 								onMouseEnter={(e) => {
 									e.currentTarget.style.background = "rgba(255,255,255,0.06)";
@@ -196,7 +204,7 @@ export default function Sidebar({
 								<span style={{ marginLeft: "auto", fontSize: 10, color: "#4d5a73", flexShrink: 0 }}>
 									{r.type}
 								</span>
-							</div>
+							</button>
 						))}
 					</div>
 				)}
@@ -214,39 +222,22 @@ export default function Sidebar({
 					{FILTERABLE_TYPES.map((type) => {
 						const active = !hiddenTypes.has(type);
 						return (
-							<button
+							<div
 								key={type}
-								onClick={() => onToggleType(type)}
 								style={{
 									display: "flex",
 									alignItems: "center",
 									gap: 8,
 									padding: isLarge ? "6px 8px" : "4px 6px",
-									cursor: "pointer",
 									fontSize: isLarge ? 14 : 12,
 									background: active ? "rgba(255,255,255,0.04)" : "transparent",
-									border: "none",
 									borderRadius: 4,
 									color: active ? "#c8d0e0" : "#4d5a73",
-									textAlign: "left",
-									width: "100%",
 									transition: "background 0.15s, color 0.15s",
-								}}
-								onMouseEnter={(e) => {
-									if (active) e.currentTarget.style.background = "rgba(255,255,255,0.07)";
-									else e.currentTarget.style.background = "rgba(255,255,255,0.03)";
-								}}
-								onMouseLeave={(e) => {
-									e.currentTarget.style.background = active
-										? "rgba(255,255,255,0.04)"
-										: "transparent";
 								}}
 							>
 								{/* Clickable color swatch — opens native color picker */}
-								<label
-									style={{ position: "relative", flexShrink: 0, cursor: "pointer" }}
-									onClick={(e) => e.stopPropagation()}
-								>
+								<label style={{ position: "relative", flexShrink: 0, cursor: "pointer" }}>
 									<span
 										style={{
 											display: "block",
@@ -276,18 +267,37 @@ export default function Sidebar({
 										title={`Change ${type} color`}
 									/>
 								</label>
-								<span style={{ flex: 1 }}>{type}</span>
-								<span
+								<button
+									type="button"
+									onClick={() => onToggleType(type)}
+									aria-pressed={active}
 									style={{
-										width: 6,
-										height: 6,
-										borderRadius: "50%",
-										background: active ? "#60a5fa" : "rgba(255,255,255,0.1)",
-										flexShrink: 0,
-										transition: "background 0.15s",
+										flex: 1,
+										display: "flex",
+										alignItems: "center",
+										gap: 8,
+										background: "transparent",
+										border: "none",
+										color: "inherit",
+										font: "inherit",
+										cursor: "pointer",
+										textAlign: "left",
+										padding: 0,
 									}}
-								/>
-							</button>
+								>
+									<span style={{ flex: 1 }}>{type}</span>
+									<span
+										style={{
+											width: 6,
+											height: 6,
+											borderRadius: "50%",
+											background: active ? "#60a5fa" : "rgba(255,255,255,0.1)",
+											flexShrink: 0,
+											transition: "background 0.15s",
+										}}
+									/>
+								</button>
+							</div>
 						);
 					})}
 				</div>
@@ -336,6 +346,7 @@ export default function Sidebar({
 						const active = focusDepth === value;
 						return (
 							<button
+								type="button"
 								key={label}
 								onClick={() => onFocusDepthChange(value)}
 								style={{
@@ -382,6 +393,7 @@ export default function Sidebar({
 					<div style={sectionHeader as React.CSSProperties}>Explorer</div>
 					{activeFolder && (
 						<button
+							type="button"
 							onClick={() => onFolderClick(null)}
 							style={{
 								fontSize: 10,
@@ -451,7 +463,9 @@ function ToggleBtn({
 	const isLarge = typeof window !== "undefined" && window.innerWidth >= 2000;
 	return (
 		<button
+			type="button"
 			onClick={onClick}
+			aria-pressed={active}
 			title={hint}
 			style={{
 				display: "flex",
@@ -523,7 +537,9 @@ function FolderItem({
 
 	return (
 		<div>
-			<div
+			<button
+				type="button"
+				aria-expanded={expanded}
 				onClick={(e) => {
 					if (e.detail === 2) {
 						// Double-click: filter graph to this folder
@@ -544,7 +560,11 @@ function FolderItem({
 					borderRadius: 3,
 					color: "#c8d0e0",
 					background: isActive ? "rgba(59,130,246,0.12)" : "transparent",
+					border: "none",
 					borderLeft: isActive ? "2px solid #60a5fa" : "2px solid transparent",
+					width: "100%",
+					textAlign: "left",
+					font: "inherit",
 				}}
 				onMouseEnter={(e) => {
 					if (!isActive) e.currentTarget.style.background = "rgba(255,255,255,0.04)";
@@ -599,7 +619,7 @@ function FolderItem({
 						FILTERED
 					</span>
 				)}
-			</div>
+			</button>
 			{expanded && (
 				<>
 					{children.map((child) => (
@@ -617,7 +637,8 @@ function FolderItem({
 						/>
 					))}
 					{fileChildren.map((fileNode) => (
-						<div
+						<button
+							type="button"
 							key={fileNode.id}
 							onClick={() => {
 								feedback?.recordClick(fileNode.id);
@@ -634,7 +655,12 @@ function FolderItem({
 								gap: 5,
 								borderRadius: 3,
 								color: "#a0aec0",
+								background: "transparent",
+								border: "none",
 								borderLeft: "2px solid transparent",
+								width: "100%",
+								textAlign: "left",
+								font: "inherit",
 							}}
 							onMouseEnter={(e) => {
 								e.currentTarget.style.background = "rgba(255,255,255,0.04)";
@@ -657,7 +683,7 @@ function FolderItem({
 							<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
 								{fileNode.label}
 							</span>
-						</div>
+						</button>
 					))}
 				</>
 			)}


### PR DESCRIPTION
## Summary

Removes the blanket Biome a11y override for `src/visualization/frontend/**` in `biome.json` and fixes all 44 resulting violations properly — no `// biome-ignore` suppressions anywhere.

### Violation breakdown (44 total)

| Rule | Count | Approach |
|---|---|---|
| `a11y/useButtonType` | 13 | Added explicit `type=\"button\"` to every SPA button |
| `a11y/noStaticElementInteractions` | 14 | Converted `<div onClick>` → `<button type=\"button\">` |
| `a11y/useKeyWithClickEvents` | 13 | Same as above (native `<button>` handles keyboard) |
| `a11y/noSvgWithoutTitle` | 3 | Added `role=\"presentation\" aria-hidden=\"true\"` to decorative SVGs |
| `suspicious/noArrayIndexKey` | 1 | `ContextMenu` keys on `item.label` |

### Notable design-level changes

- **Modal backdrops** (`ShortcutsModal`, `SearchOverlay`, mobile sidebar overlay): the click-to-dismiss background became a full-viewport `<button type=\"button\">` with `aria-label`; the dialog content moved to a sibling `<div role=\"dialog\" aria-modal=\"true\">`. No more nested-interactive anti-pattern.
- **Node Types sidebar row** (`Sidebar.tsx`): previously nested an interactive `<input type=\"color\">` + `<label>` inside a `<button>` — invalid HTML. Restructured as a flex row with the swatch-label and the toggle button as siblings.
- **`FolderItem`** in the explorer tree: outer `<div role=\"button\" tabIndex={0}>` became a native `<button type=\"button\">` with `aria-expanded`. `e.detail === 2` double-click detection still works on buttons.
- **Bookmarks row** in `GraphCanvas.tsx`: previously had a button nested inside a clickable div (invalid HTML). Split into two sibling buttons: \"load bookmark\" and \"delete bookmark\" (`aria-label`ed).
- **Search result rows** (`SearchOverlay.tsx`, `Sidebar.tsx`): converted to `<button>` elements with reset styles (background transparent, border none, full width, left-aligned text) so visual parity is preserved.

### Accessibility affordances added

- `aria-pressed` on toggle-style buttons (node-type filters, layout mode, blast/color/hulls toggles, inspector tabs).
- `aria-expanded` on folder tree entries.
- `aria-label` on icon-only buttons (hamburger, close, delete, resize handle, etc.).
- `role=\"dialog\" aria-modal=\"true\"` on overlay modal content.
- `role=\"menu\"` / `role=\"menuitem\"` on `ContextMenu`.

### No-surprise cases

- Zero `// biome-ignore` suppressions added.
- Decorative SVG icons use `role=\"presentation\" aria-hidden=\"true\"` rather than empty `<title>`.
- Button reset styles (`background: transparent`, `border: none`, `font: inherit`, `color: inherit`, `width: 100%`, `textAlign: left`, `padding: 0` where appropriate) applied explicitly to avoid UA button styling bleeding into the dark glass UI.

### Version / changelog

- `.claude-plugin/plugin.json`: 1.1.1 → 1.1.2
- `.claude-plugin/marketplace.json`: 1.1.1 → 1.1.2 (three occurrences)
- `CHANGELOG.md`: new `[1.1.2] - 2026-04-21` entry under `### Fixed`

## Test plan

- [x] `bunx @biomejs/biome check .` — 0 errors
- [x] `bunx tsc --noEmit` (root) — clean
- [x] `bunx tsc --noEmit` (`src/visualization/frontend/`) — clean
- [x] `bun test tests/unit/visualization/` — 20/20 pass
- [x] `cd src/visualization/frontend && bun run build` — succeeds
- [ ] Manual: sanity-check observatory UI with keyboard navigation (tab through folder tree, search results, toggle buttons; Escape closes modals; Enter/Space activates)
- [ ] Manual: screen-reader smoke test on macOS VoiceOver