### PR TITLE
fix(native): probe detectCommunities; doctor honesty; test-runner doc; v1.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.3"
+		"version": "1.1.4"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.3",
+			"version": "1.1.4",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -32,5 +32,5 @@
 			]
 		}
 	],
-	"version": "1.1.3"
+	"version": "1.1.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-04-21
+
+### Fixed
+- Community-detection bridge no longer attempts to call `detectCommunities`
+  on the native module unconditionally. The current `@sia/native` binary
+  exposes `astDiff`, `graphCompute`, `isNative`, and `isWasm`, but does
+  **not** yet include a Rust Leiden implementation. Before this fix the
+  bridge logged "sia: native Leiden failed at runtime: nativeMod.detectCommunities
+  is not a function — using JS fallback" on every community-detection call.
+  Detection now probes for the function and silently falls through to JS
+  Louvain when it is missing.
+- `sia doctor` reported "Rust Leiden via graphrs" whenever any tier of the
+  native module loaded. It now uses the new `isLeidenAvailable()` probe and
+  only claims Leiden when the native module genuinely exports it.
+
+### Added
+- README "Running the Test Suite" section clarifying `bun run test`
+  (vitest, 2021/2021 pass) vs `bun test` (Bun's native runner, ~400
+  bogus failures from `vi.mock` leakage across files).
+- `vitest.config.ts` top-of-file banner with the same note so agents or
+  contributors touching test configuration see the warning immediately.
+
 ## [1.1.3] - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ sia doctor                          # Health check
 /sia-visualize-live                 # Graph explorer in your browser
 ```
 
+### Running the Test Suite
+
+Always run tests via the `bun run` wrapper so vitest picks up the project
+config. `bun test` invokes Bun's own test runner, which bypasses
+`vitest.config.ts`, skips the `@/…` path aliases, and runs every test file
+in a single shared process — which makes the `vi.mock(...)` calls in
+several tests (e.g. the C# project extractor) leak across file boundaries
+and produces spurious failures.
+
+```bash
+bun run test         # Correct — 2021/2021 pass
+bun test             # Incorrect — shows ~400 bogus failures
+```
+
+CI uses `bun run test`.
+
 ---
 
 ## How It Works

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -10,6 +10,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { isLeidenAvailable } from "@/community/detection-bridge";
 import type { SiaDb } from "@/graph/db-interface";
 import { detectAgent, getRecommendedCaptureMode } from "@/hooks/agent-detect";
 import { getHookConfig } from "@/hooks/event-router";
@@ -69,8 +70,9 @@ export async function runDoctor(
 	});
 
 	// 3. Community detection backend
-	const communityBackend =
-		nativeStatus !== "typescript" ? "Rust Leiden via graphrs" : "JavaScript Louvain (in-process)";
+	const communityBackend = isLeidenAvailable()
+		? "Rust Leiden via graphrs"
+		: "JavaScript Louvain (in-process)";
 	checks.push({
 		name: "Community detection",
 		status: "ok",

--- a/src/community/detection-bridge.ts
+++ b/src/community/detection-bridge.ts
@@ -33,13 +33,31 @@ interface NativeLeidenModule {
 	): CommunityResult;
 }
 
+/**
+ * Probe @sia/native for a `detectCommunities` export. The current native
+ * binary does not yet expose Leiden (only astDiff and graphCompute), so
+ * this returns null when the function is missing and the caller falls
+ * through to the JS Louvain implementation silently.
+ */
 function loadNativeLeiden(): NativeLeidenModule | null {
 	try {
-		return require("@sia/native") as NativeLeidenModule;
+		const mod = require("@sia/native") as Partial<NativeLeidenModule>;
+		if (typeof mod.detectCommunities === "function") {
+			return mod as NativeLeidenModule;
+		}
+		return null;
 	} catch {
-		process.stderr.write("sia: native Leiden module not available, using JS fallback\n");
 		return null;
 	}
+}
+
+/**
+ * Returns true when the native module exposes a working `detectCommunities`
+ * export. Used by `sia doctor` to label the active community-detection
+ * backend accurately.
+ */
+export function isLeidenAvailable(): boolean {
+	return loadNativeLeiden() !== null;
 }
 
 // ---------------------------------------------------------------------------

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,12 @@
+// Vitest configuration for the main test suite.
+//
+// IMPORTANT: run tests via `bun run test` (which invokes vitest) rather than
+// `bun test` (Bun's native runner). `bun test` ignores this config file, the
+// `@/…` alias map, and the per-file isolation that prevents `vi.mock(...)`
+// pollution across test files. Running `bun test` directly will appear to
+// produce several hundred failures; those failures are an artefact of the
+// wrong runner, not real regressions.
+
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 


### PR DESCRIPTION
## Summary

Follow-up polish after #63 landed `@sia/native`.

1. **Stderr regression** — wiring `@sia/native` caused `detection-bridge.ts` to start successfully `require()`-ing the module and then unconditionally calling `nativeMod.detectCommunities(...)`. That function does not exist in the current Rust crate (which exposes only `astDiff`, `graphCompute`, `isNative`, `isWasm`), so every community-detection call logged "sia: native Leiden failed at runtime: nativeMod.detectCommunities is not a function — using JS fallback". The bridge now probes for the function and silently falls through to JS Louvain when it is missing.
2. **`sia doctor` was lying** — it reported "Rust Leiden via graphrs" whenever the native tier was loaded, even though the binary has no Leiden impl. Now uses `isLeidenAvailable()` and only claims Leiden when the function is actually exported.
3. **Test-runner documentation** — adds a README section and a banner comment in `vitest.config.ts` explaining that `bun run test` (vitest, 2021/2021 pass) is the canonical runner. `bun test` bypasses `vitest.config.ts`, the `@/…` alias map, and per-file isolation — it surfaces ~400 spurious failures from `vi.mock` leakage across files. The repo's CI already uses `bun run test`; the note is for developers / AI agents who reflexively type `bun test`.

## Test plan

- [x] `bun run test` — 2021/2021 pass, zero stderr noise
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx @biomejs/biome check src/community/detection-bridge.ts src/cli/commands/doctor.ts vitest.config.ts README.md CHANGELOG.md .claude-plugin/` — 5 files, 0 errors
- [x] `bun src/cli/index.ts doctor` — now reports "Community detection: JavaScript Louvain (in-process)" on this machine, because the Rust binary doesn't yet expose Leiden. When Leiden ships in `sia-native`, the same doctor code path will flip to "Rust Leiden via graphrs" automatically with no downstream changes needed.

## Follow-up (not in this PR)

Adding a Rust Leiden implementation to `sia-native` (so `detectCommunities` actually exists) is tracked separately — it requires adding a Leiden-capable crate like `graphrs`, writing the NAPI binding, rebuilding the `.node` binary per platform, and adding parity tests vs the JS Louvain fallback.