### PR TITLE
chore(plugin): documentation truth + scaffolding (phase 1); v1.1.5

### DIFF
--- a/.claude-plugin/icon.svg
+++ b/.claude-plugin/icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Sia">
+  <title>Sia</title>
+  <rect width="512" height="512" rx="96" fill="#0f172a"/>
+  <g stroke="#38bdf8" stroke-width="6" stroke-linecap="round">
+    <line x1="256" y1="160" x2="144" y2="272"/>
+    <line x1="256" y1="160" x2="368" y2="272"/>
+    <line x1="256" y1="160" x2="256" y2="360"/>
+    <line x1="144" y1="272" x2="256" y2="360"/>
+    <line x1="368" y1="272" x2="256" y2="360"/>
+  </g>
+  <g fill="#38bdf8">
+    <circle cx="256" cy="160" r="28"/>
+    <circle cx="144" cy="272" r="28"/>
+    <circle cx="368" cy="272" r="28"/>
+    <circle cx="256" cy="360" r="28"/>
+  </g>
+  <circle cx="256" cy="160" r="10" fill="#0f172a"/>
+</svg>

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.4"
+		"version": "1.1.5"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.4",
+			"version": "1.1.5",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -21,16 +21,17 @@
 			"license": "Apache-2.0",
 			"category": "development",
 			"keywords": [
+				"claude-code",
+				"claude",
 				"memory",
 				"knowledge-graph",
 				"mcp",
 				"ai-coding",
 				"persistent-memory",
 				"bi-temporal",
-				"tree-sitter",
-				"cross-session"
+				"agent-memory"
 			]
 		}
 	],
-	"version": "1.1.4"
+	"version": "1.1.5"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,23 +1,25 @@
 {
 	"name": "sia",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"
 	},
 	"license": "Apache-2.0",
 	"category": "development",
+	"icon": "./icon.svg",
 	"repository": "https://github.com/rkarim08/sia",
 	"homepage": "https://github.com/rkarim08/sia#readme",
 	"bugs": "https://github.com/rkarim08/sia/issues",
 	"keywords": [
 		"claude-code",
-		"plugin",
+		"claude",
 		"memory",
 		"knowledge-graph",
 		"mcp",
 		"ai-coding",
 		"persistent-memory",
-		"bi-temporal"
+		"bi-temporal",
+		"agent-memory"
 	]
 }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -502,13 +502,13 @@ Two implementations: `BunSqliteDb` (local-only, sync API) and `LibSqlDb` (team s
 
 #### Module 5: MCP Server
 
-**Purpose:** Expose 17 tools over stdio transport. Strictly read-only on the main graph.
+**Purpose:** Expose 29 tools over stdio transport. Strictly read-only on the main graph.
 
 **Key files:** `src/mcp/server.ts`, `src/mcp/tools/` (one file per tool)
 
 **Security model:** Graph opened with `OPEN_READONLY`. Separate WAL-mode write connections for event nodes, `session_flags`, and `session_resume`. All inputs Zod-validated.
 
-**17 tools:** Memory (`sia_search`, `sia_by_file`, `sia_expand`, `sia_community`, `sia_at_time`, `sia_flag`, `sia_note`, `sia_backlinks`), Sandbox (`sia_execute`, `sia_execute_file`, `sia_batch_execute`, `sia_index`, `sia_fetch_and_index`), Diagnostic (`sia_stats`, `sia_doctor`, `sia_upgrade`), Models (`sia_models`).
+**29 tools:** 24 `sia_*` + 5 `nous_*`. Memory (`sia_search`, `sia_by_file`, `sia_expand`, `sia_community`, `sia_at_time`, `sia_flag`, `sia_note`, `sia_backlinks`), Sandbox (`sia_execute`, `sia_execute_file`, `sia_batch_execute`, `sia_index`, `sia_fetch_and_index`), Diagnostic (`sia_stats`, `sia_doctor`, `sia_upgrade`, `sia_sync_status`), Models (`sia_models`), AST (`sia_ast_query`), Branch Snapshots (`sia_snapshot_list`, `sia_snapshot_restore`, `sia_snapshot_prune`), Nous (`nous_state`, `nous_reflect`, `nous_curiosity`, `nous_concern`, `nous_modify`).
 
 **Dependencies:** Modules 1, 4, 6, 9, 10
 
@@ -518,7 +518,7 @@ Two implementations: `BunSqliteDb` (local-only, sync API) and `LibSqlDb` (team s
 
 **Key files:** `.claude-plugin/plugin.json`, `.mcp.json`, `hooks/hooks.json`, `skills/`, `agents/`, `scripts/`
 
-**Extension points:** MCP (`.mcp.json`, 17 tools), Hooks (`hooks/hooks.json`, real-time capture), Skills (`skills/*.md`, slash commands), Agents (`agents/*.md`, autonomous analysis), CLAUDE.md (behavioral directives). Plugin mode uses `CLAUDE_PLUGIN_DATA` for state; standalone uses `~/.sia/`.
+**Extension points:** MCP (`.mcp.json`, 29 tools), Hooks (`hooks/hooks.json`, real-time capture), Skills (`skills/*.md`, slash commands), Agents (`agents/*.md`, autonomous analysis), CLAUDE.md (behavioral directives). Plugin mode uses `CLAUDE_PLUGIN_DATA` for state; standalone uses `~/.sia/`.
 
 **Dependencies:** Module 5 (MCP), Module 14 (hooks), Module 17 (CLAUDE.md generation)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -508,7 +508,7 @@ Two implementations: `BunSqliteDb` (local-only, sync API) and `LibSqlDb` (team s
 
 **Security model:** Graph opened with `OPEN_READONLY`. Separate WAL-mode write connections for event nodes, `session_flags`, and `session_resume`. All inputs Zod-validated.
 
-**29 tools:** 24 `sia_*` + 5 `nous_*`. Memory (`sia_search`, `sia_by_file`, `sia_expand`, `sia_community`, `sia_at_time`, `sia_flag`, `sia_note`, `sia_backlinks`), Sandbox (`sia_execute`, `sia_execute_file`, `sia_batch_execute`, `sia_index`, `sia_fetch_and_index`), Diagnostic (`sia_stats`, `sia_doctor`, `sia_upgrade`, `sia_sync_status`), Models (`sia_models`), AST (`sia_ast_query`), Branch Snapshots (`sia_snapshot_list`, `sia_snapshot_restore`, `sia_snapshot_prune`), Nous (`nous_state`, `nous_reflect`, `nous_curiosity`, `nous_concern`, `nous_modify`).
+**29 tools:** 24 `sia_*` + 5 `nous_*`. Memory (`sia_search`, `sia_by_file`, `sia_expand`, `sia_community`, `sia_at_time`, `sia_flag`, `sia_note`, `sia_backlinks`), Sandbox (`sia_execute`, `sia_execute_file`, `sia_batch_execute`, `sia_index`, `sia_fetch_and_index`), Diagnostic (`sia_stats`, `sia_doctor`, `sia_upgrade`, `sia_sync_status`), Models (`sia_models`), AST (`sia_ast_query`), Change Analysis (`sia_detect_changes`, `sia_impact`), Branch Snapshots (`sia_snapshot_list`, `sia_snapshot_restore`, `sia_snapshot_prune`), Nous (`nous_state`, `nous_reflect`, `nous_curiosity`, `nous_concern`, `nous_modify`).
 
 **Dependencies:** Modules 1, 4, 6, 9, 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-04-21
+
+### Changed
+- Plugin documentation counts corrected to match reality: 29 MCP tools
+  (24 sia_* + 5 nous_*), 48 skills, 73 commands, 9 hook entries across 7
+  event types. Previously the README mixed "17 tools" and "22 MCP tools"
+  on different lines, and "46 skills" was stale by 2.
+- Consolidated the keyword arrays in `.claude-plugin/plugin.json` and
+  `.claude-plugin/marketplace.json` to the same authoritative list.
+  Dropped the redundant `plugin` tag; added `claude` and `agent-memory`
+  for discovery.
+
+### Added
+- `## Troubleshooting` section in README covering bun install, MCP
+  handshake failures, native tree-sitter build, SQLite/FTS5, doctor
+  warnings, empty graphs, and Nous drift warnings.
+- `scripts/count-plugin-components.sh` — prints authoritative component
+  counts. Used by the plugin validator (lands in Phase 5) to detect
+  documentation drift automatically.
+- `SECURITY.md` describing the threat model for `sia_execute*`, the
+  ensure-runtime bun install behaviour, and the postinstall `.git` strip.
+- `CONTRIBUTING.md` with branch-naming convention, the `bun run test` vs
+  `bun test` distinction, lint/typecheck commands, and commit-message
+  conventions (no Claude attribution, no Co-Authored-By).
+- `.claude-plugin/icon.svg` + `icon` field in plugin.json for marketplace
+  rendering.
+
 ## [1.1.4] - 2026-04-21
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Sia
+
+Thanks for your interest in contributing. This guide covers the conventions this repo relies on. Keep changes focused and follow the patterns already in the codebase.
+
+## Branch naming
+
+Use phase-named branches that describe the body of work. No `feature/`, `fix/`, or `chore/` prefixes.
+
+Examples:
+- `plugin-polish-docs`
+- `nous-enabled-flag`
+- `transformer-stack-activation`
+
+## Running tests
+
+Always run the test suite via the `bun run` wrapper so vitest picks up `vitest.config.ts`:
+
+```bash
+bun run test
+```
+
+**Do not run `bun test`.** Bun's native test runner bypasses `vitest.config.ts`, skips the path aliases, and surfaces ~400 bogus failures from `vi.mock` leakage across files. The `vitest.config.ts` top-of-file banner (added in v1.1.4) documents this distinction.
+
+The baseline is 2021/2021 passing at v1.1.4.
+
+## Type checking
+
+```bash
+bunx tsc --noEmit
+```
+
+Must be clean before opening a PR.
+
+## Linting
+
+```bash
+bunx @biomejs/biome check .
+```
+
+Biome excludes `**/*.md`, so markdown files are not linted, but JSON/TS/JS files are.
+
+## Plugin validator
+
+A plugin validator script lands in Phase 5 and will wire `scripts/count-plugin-components.sh` into the drift check. For now, run that script manually to verify the authoritative component counts:
+
+```bash
+bash scripts/count-plugin-components.sh
+```
+
+## Commit messages
+
+Conventional-commit subjects (e.g. `fix(native): …`, `feat(mcp): …`, `docs: …`).
+
+**Do not add any of the following:**
+- `Co-Authored-By: Claude …` trailers
+- `Generated with Claude Code` lines
+- Any other AI tool attribution
+
+These are a standing repo convention. If you use an AI tool to draft changes, that's fine — just don't attribute it in commits or PR bodies.
+
+## Pull requests
+
+- One coherent change per PR; squash when merging unless the history has real value.
+- PR titles follow the same conventional-commit format as commits.
+- Include a short test plan or a note on how you verified the change locally.
+- PR bodies must not include Claude / Claude Code / Codex attribution.
+
+## Before opening a PR
+
+Run in order:
+
+```bash
+bun run test
+bunx tsc --noEmit
+bunx @biomejs/biome check .
+bash scripts/count-plugin-components.sh
+```
+
+All four should succeed cleanly.

--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -73,7 +73,7 @@ claude --plugin-dir /path/to/sia
 | `sia_upgrade` | Self-update SIA to the latest version |
 | `sia_sync_status` | Check team sync configuration and connection status |
 
-### Skills (46 slash commands)
+### Skills (48 slash commands)
 
 #### Core
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Sia gives your agent a typed, temporal, ontology-enforced knowledge graph that c
 | **Context cost** | Grows unbounded with project maturity | Grows with entries | Manual copy-paste to agent | ~1,200 tokens average per session (only relevant facts retrieved) |
 | **Code structure** | Not captured | Not captured | Not captured | AST-powered structural backbone via Tree-sitter (30+ languages) |
 | **Documentation ingestion** | Not captured | Not captured | Manual note creation | Auto-discovers and indexes AGENTS.md, CLAUDE.md, ADRs, README.md, and 15+ doc formats |
-| **Agent integration** | Injected at session start | MCP tool calls | None native; requires manual bridging | Native MCP server with 17 tools, automatic hook-based capture |
+| **Agent integration** | Injected at session start | MCP tool calls | None native; requires manual bridging | Native MCP server with 29 tools (24 `sia_*` + 5 `nous_*`), automatic hook-based capture |
 | **Sandbox execution** | N/A | N/A | N/A | Isolated subprocess execution with context-aware output indexing |
 | **Session continuity** | Lost on compaction | Lost on compaction | N/A | Priority-weighted subgraph serialization survives context compaction |
 | **Knowledge authoring** | Developer writes manually | Developer writes manually | Developer writes manually (rich editor) | `sia_note` for deliberate entry + automatic dual-track capture |
@@ -66,7 +66,7 @@ Sia gives your agent a typed, temporal, ontology-enforced knowledge graph that c
 /plugin install sia@sia-plugins
 ```
 
-This registers all 22 MCP tools, 46 skills, 23 agents, 8 hooks, and CLAUDE.md behavioral directives in one step.
+This registers all 29 MCP tools, 48 skills, 23 agents, 9 hook entries across 7 event types, and CLAUDE.md behavioral directives in one step.
 
 > **Coming soon:** Once Sia is accepted into the official Anthropic marketplace, installation will simplify to `/plugin install sia@claude-plugins-official`.
 
@@ -316,9 +316,9 @@ Sia uses a unified graph with a `kind` discriminator. Nodes fall into three cate
 
 ---
 
-## MCP Tools (17)
+## MCP Tools (29)
 
-Sia exposes 17 tools via the Model Context Protocol, organized into five categories.
+Sia exposes 29 tools via the Model Context Protocol, organized into five categories.
 
 ### Memory Tools
 
@@ -532,7 +532,7 @@ Matching slash commands — `/nous-state`, `/nous-reflect`, `/nous-curiosity`, `
 
 ---
 
-## Skills (46)
+## Skills (48)
 
 Skills are slash commands providing structured workflows. Invoke them in Claude Code with `/sia-<name>`.
 
@@ -1074,6 +1074,45 @@ Auto-detected from `pnpm-workspace.yaml`, `package.json` workspaces, `nx.json`, 
 **`/sia-tour`** -- Interactive guided tour covering architecture, decisions, conventions, and known issues.
 
 **`/sia-export-knowledge`** -- Exports the graph as a human-readable `KNOWLEDGE.md` for team onboarding, sharing outside SIA, or generating project documentation.
+
+---
+
+## Troubleshooting
+
+### `bun install` fails
+
+If you don't have bun installed, Sia's `ensure-runtime.sh` bootstrap runs `curl -fsSL https://bun.sh/install | bash` to install bun at `$HOME/.bun/` on the first hook fire. If you prefer a manual install or run on a locked-down system, install bun >=1.0.0 first and the auto-install will short-circuit.
+
+### MCP handshake fails
+
+Check your Claude Code MCP log (path depends on your Claude Code version — typically `~/.claude/mcp/sia.log` or surfaced by `/mcp` in the UI). Common cause: `scripts/start-mcp.sh` exits non-zero because `$CLAUDE_PLUGIN_ROOT` is unset, meaning the plugin was not installed through the marketplace flow. Reinstall via `/plugin install sia@sia-plugins` to restore the environment.
+
+### Native tree-sitter build fails
+
+`postinstall.sh` attempts a C++20 rebuild of the `tree-sitter` native module. If your system only has C++11 headers, Sia silently falls back to the WASM tree-sitter build. If you want the native speedup, install a modern compiler toolchain (Xcode CLT on macOS; `build-essential` + `g++-11` on Debian/Ubuntu) and run manually:
+
+```bash
+cd node_modules/tree-sitter
+CXXFLAGS="-std=c++20" npx node-gyp rebuild
+```
+
+### SQLite extensions / FTS5 missing
+
+Sia's retrieval uses FTS5 and optional vector indexing. `bun:sqlite` ships with FTS5 built in. If you see errors about missing extensions, verify `bun --version` reports >= 1.0.0.
+
+### `sia doctor` reports warnings
+
+Run `sia doctor` to surface the warning details. Common warnings:
+- "Native module: Using TypeScript fallbacks" — install `@sia/native` (ships on darwin-arm64 out of the box; other platforms fall through to TS).
+- "ONNX embedding model: missing" — run `/sia-setup` or `sia install --t0` to download the bge-small embedding model.
+
+### Empty graph after install
+
+If `sia search` returns no results and `sia stats` reports zero entities, the graph hasn't been indexed yet. Run `/sia-setup` for the guided bootstrap, or `sia learn` directly.
+
+### `[Nous] Drift warning` in session output
+
+Drift is measured from your captured Preference nodes. Call `/nous-reflect` to see per-Preference alignment and the recommended action.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported versions
+
+Latest minor only. Upgrade before reporting.
+
+## Reporting a vulnerability
+
+Open a private advisory at https://github.com/rkarim08/sia/security/advisories/new. Do not file public issues for security reports.
+
+## Threat model
+
+Sia runs local-only by default. The sandbox executor (`sia_execute`, `sia_execute_file`, `sia_batch_execute`) spawns subprocesses under the user's shell. Inputs should be treated as developer-authored code — not untrusted user input. If your project exposes Sia's MCP server to an untrusted network, disable these tools via your MCP client configuration.
+
+## Known surfaces
+
+- SQLite graph at `$SIA_HOME/repos/<hash>/graph.db` — readable by anyone with filesystem access.
+- `postinstall.sh` strips `.git` from `$PLUGIN_ROOT` when installed under `/.claude/plugins/`. The strip is gated on path substring matching.
+- `ensure-runtime.sh` installs bun to `$HOME/.bun/` on the first hook fire without prompting.

--- a/scripts/count-plugin-components.sh
+++ b/scripts/count-plugin-components.sh
@@ -4,12 +4,12 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-skills=$(ls -d skills/*/ 2>/dev/null | wc -l | tr -d ' ')
-agents=$(ls agents/*.md 2>/dev/null | wc -l | tr -d ' ')
-commands=$(ls commands/*.md 2>/dev/null | wc -l | tr -d ' ')
-mcp_tools=$(grep -oE '"(sia_|nous_)[a-z_]+"' src/mcp/server.ts | sort -u | wc -l | tr -d ' ')
-hook_entries=$(jq '[.hooks | to_entries[] | .value[]] | length' hooks/hooks.json)
-hook_events=$(jq '.hooks | keys | length' hooks/hooks.json)
+skills=$( { ls -d skills/*/ 2>/dev/null || true; } | wc -l | tr -d ' ')
+agents=$( { ls agents/*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+commands=$( { ls commands/*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+mcp_tools=$( { grep -oE '"(sia_|nous_)[a-z_]+"' src/mcp/server.ts 2>/dev/null || true; } | sort -u | wc -l | tr -d ' ')
+hook_entries=$(jq '[.hooks | to_entries[] | .value[]] | length' hooks/hooks.json 2>/dev/null || echo 0)
+hook_events=$(jq '.hooks | keys | length' hooks/hooks.json 2>/dev/null || echo 0)
 
 echo "Skills:       ${skills}"
 echo "Agents:       ${agents}"

--- a/scripts/count-plugin-components.sh
+++ b/scripts/count-plugin-components.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Prints authoritative component counts. Used by validate-plugin.sh (Phase 5)
+# to detect documentation drift.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+skills=$(ls -d skills/*/ 2>/dev/null | wc -l | tr -d ' ')
+agents=$(ls agents/*.md 2>/dev/null | wc -l | tr -d ' ')
+commands=$(ls commands/*.md 2>/dev/null | wc -l | tr -d ' ')
+mcp_tools=$(grep -oE '"(sia_|nous_)[a-z_]+"' src/mcp/server.ts | sort -u | wc -l | tr -d ' ')
+hook_entries=$(jq '[.hooks | to_entries[] | .value[]] | length' hooks/hooks.json)
+hook_events=$(jq '.hooks | keys | length' hooks/hooks.json)
+
+echo "Skills:       ${skills}"
+echo "Agents:       ${agents}"
+echo "Commands:     ${commands}"
+echo "MCP tools:    ${mcp_tools}"
+echo "Hook entries: ${hook_entries}"
+echo "Hook events:  ${hook_events}"


### PR DESCRIPTION
## Summary

Phase 1 of the plugin polish plan ([docs/superpowers/plans/2026-04-21-plugin-polish.md](docs/superpowers/plans/2026-04-21-plugin-polish.md), gitignored). Documentation-only pass that closes the worst credibility gap — the README advertised wrong counts on multiple lines and contradicted itself.

### Changed

- **Count drift fixed.** Ground truth as of v1.1.5: **29 MCP tools** (24 `sia_*` + 5 `nous_*`), **48 skills**, **23 agents**, **73 commands**, **9 hook entries across 7 event types**. Previously the README variously claimed 17 / 22 on different lines, 46 skills (stale by 2), and 8 hooks. Fixed in `README.md`, `PLUGIN_README.md`, and `ARCHITECTURE.md`.
- **Keyword consolidation** — `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` keyword arrays are now byte-identical (`["claude-code", "claude", "memory", "knowledge-graph", "mcp", "ai-coding", "persistent-memory", "bi-temporal", "agent-memory"]`). Dropped redundant `plugin`; added `claude` + `agent-memory` for discovery.

### Added

- **Troubleshooting section** in README (7 topics: bun install, MCP handshake, native tree-sitter build, SQLite/FTS5, doctor warnings, empty graph, Nous drift).
- **`scripts/count-plugin-components.sh`** — prints authoritative counts. Used by the Phase 5 validator to catch future drift automatically. Robust to missing dirs (degrades to zeros, not crashes).
- **`SECURITY.md`** — threat model for `sia_execute*`, ensure-runtime bun install behaviour, postinstall `.git` strip.
- **`CONTRIBUTING.md`** — branch naming, `bun run test` vs `bun test`, lint/typecheck, no-attribution rule.
- **`.claude-plugin/icon.svg`** (723 B, self-contained) + `"icon"` field in plugin.json.

## Test plan

- [x] `bun run test` — 2021/2021 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx @biomejs/biome check .` — 557 files, 0 errors
- [x] `bash scripts/count-plugin-components.sh` — prints `Skills: 48, Agents: 23, Commands: 73, MCP tools: 29, Hook entries: 9, Hook events: 7`
- [x] Missing-dir simulation — script degrades to zeros instead of crashing
- [x] JSON files parse; keyword arrays byte-equivalent (verified via `diff`)
- [x] SVG parses (`xmllint --noout`); < 10 KB; no external refs
- [x] No Co-Authored-By / Claude attribution in any commit

## Commits

- `0e56893` — doc truth scaffolding
- `be6b187` — ARCHITECTURE.md enumeration completeness
- `c1cc6b1` — count-plugin-components.sh missing-dir robustness (post-review)