### PR TITLE
docs(plugin): per-component user guides (phase 3); v1.1.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.6"
+		"version": "1.1.7"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.6",
+			"version": "1.1.7",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.1.6"
+	"version": "1.1.7"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ All notable changes to Sia are documented here. This project adheres to
   usage guide with invocation triggers and worked examples. Linked
   from README and PLUGIN_README as the canonical entry point for
   "how do I use X?" questions.
-- Uniform "Usage" section on 41 skills that were previously thin or
-  missing usage documentation. The contract (what it does / when to
-  invoke / inputs / worked example) is now consistent across every
-  skill the plugin ships.
-- Context blurbs on 26 agent-delegation commands so users reading the
+- Added or expanded "Usage" documentation on 38 skills that were
+  previously thin or missing it. Individual skills keep their
+  existing section structure (some use `## Usage`, others split
+  into `## When To Use` + `## Worked Example`) — the contract is
+  semantic, not syntactic: every skill now covers what it does,
+  when to invoke, inputs, and a worked example or typical output.
+- Context blurbs on 22 agent-delegation commands so users reading the
   command body understand what the underlying agent does without
   round-tripping to the agent file.
 - Positive worked examples on the 5 `/nous-*` commands (previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.1.7] - 2026-04-21
+
+### Added
+- `PLUGIN_USAGE.md` — consolidated per-skill, per-agent, per-command
+  usage guide with invocation triggers and worked examples. Linked
+  from README and PLUGIN_README as the canonical entry point for
+  "how do I use X?" questions.
+- Uniform "Usage" section on 41 skills that were previously thin or
+  missing usage documentation. The contract (what it does / when to
+  invoke / inputs / worked example) is now consistent across every
+  skill the plugin ships.
+- Context blurbs on 26 agent-delegation commands so users reading the
+  command body understand what the underlying agent does without
+  round-tripping to the agent file.
+- Positive worked examples on the 5 `/nous-*` commands (previously
+  safety-rules only).
+- `scripts/generate-plugin-usage.sh` — walks skills/agents/commands
+  and regenerates PLUGIN_USAGE.md tables. Supports `--verify` for
+  drift detection (used by the Phase 6 validator).
+
+### Changed
+- README and PLUGIN_README point to PLUGIN_USAGE.md as the
+  per-component entry point.
+
 ## [1.1.6] - 2026-04-21
 
 ### Removed

--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -18,6 +18,10 @@ claude --plugin-dir /path/to/sia
 > **Note:** Local development mode (`--plugin-dir`) is project-scoped.
 > For cross-project usage, install from the marketplace.
 
+### Full component usage
+
+See [PLUGIN_USAGE.md](PLUGIN_USAGE.md) for per-skill, per-agent, per-command usage guides with invocation triggers and worked examples.
+
 ## Features
 
 ### MCP Tools (always available)

--- a/PLUGIN_USAGE.md
+++ b/PLUGIN_USAGE.md
@@ -1,0 +1,171 @@
+# Sia Plugin Usage Guide
+
+This guide indexes every capability the Sia Claude Code plugin ships. For deep documentation on any component, follow the link.
+
+See also: [README.md](README.md) (product overview), [CLAUDE.md](CLAUDE.md) (agent behavioural contract), [ARCHITECTURE.md](ARCHITECTURE.md) (system design).
+
+## Quick start
+
+| I want to...                       | Command or skill                    |
+|------------------------------------|-------------------------------------|
+| Install Sia for the first time     | `/sia-setup`                        |
+| Build / refresh the graph          | `/sia-learn` · `/sia-learn --incremental` |
+| Search the graph                   | `/sia-search <query>`               |
+| Look up a file in the graph        | `sia_by_file` MCP tool              |
+| Visualize the graph interactively  | `/sia-visualize-live`               |
+| Check plugin health                | `/sia-doctor`                       |
+| Capture a decision manually        | `/sia-capture`                      |
+| Review knowledge graph state       | `/sia-status` · `/sia-stats`        |
+| Understand the current session     | `/nous-state`                       |
+| Debug a regression                 | `/sia-debug-workflow`               |
+| Plan a feature                     | `/sia-plan`                         |
+| Wrap up a branch                   | `/sia-finish`                       |
+
+Shortest path for a new user: `/sia-setup` → `/sia-tour` → start working normally. Sia captures automatically; you only call skills when you want a targeted action.
+
+## Skills (47)
+
+### Core
+
+| Skill | What it does | When to invoke |
+|---|---|---|
+| [sia-setup](skills/sia-setup/SKILL.md) | Guided first-run bootstrap (install + learn + tour) | Fresh install; first session on a new repo |
+| [sia-install](skills/sia-install/SKILL.md) | Creates databases + registers repo (no indexing) | DB scaffold when you want to learn manually |
+| [sia-learn](skills/sia-learn/SKILL.md) | Full / incremental graph build | First index; after big refactor; stale graph |
+| [sia-search](skills/sia-search/SKILL.md) | Hybrid graph retrieval | Any moment you need prior context |
+| [sia-capture](skills/sia-capture/SKILL.md) | Guided knowledge-capture session | End of a session; after architectural decisions |
+| [sia-nous](skills/sia-nous/SKILL.md) | Cognitive layer tool selector | Drift warnings; anti-sycophancy; Preference edits |
+| [sia-tour](skills/sia-tour/SKILL.md) | Interactive guided tour of what SIA knows | Onboarding; post-learn inspection |
+| [sia-playbooks](skills/sia-playbooks/SKILL.md) | Loads task-specific playbooks (CLAUDE.md uses this) | Task classifier routes here automatically |
+
+### Knowledge management
+
+| Skill | What it does | When to invoke |
+|---|---|---|
+| [sia-augment](skills/sia-augment/SKILL.md) | Proactive capture assist | After ambiguous "we're doing X now" moments |
+| [sia-digest](skills/sia-digest/SKILL.md) | 24-hour knowledge digest | Start of workday; daily standup |
+| [sia-history](skills/sia-history/SKILL.md) | Temporal explore of graph evolution | "What decisions were made this week?" |
+| [sia-compare](skills/sia-compare/SKILL.md) | Diff graph state across two time points | Release retro; sprint audit |
+| [sia-at-time](skills/sia-at-time/SKILL.md) | Query graph as-of a historical moment | Regression root cause; audit |
+| [sia-community-inspect](skills/sia-community-inspect/SKILL.md) | Inspect community partitioning | Module-boundary understanding; dispatch checks |
+| [sia-conflicts](skills/sia-conflicts/SKILL.md) | List/resolve knowledge conflicts | Conflict flag appears; post-import cleanup |
+| [sia-freshness](skills/sia-freshness/SKILL.md) | Fresh/stale/rotten classification | Weekly health check; pre-prune |
+| [sia-prune](skills/sia-prune/SKILL.md) | Hard-delete archived entities | DB size grows; after freshness scan |
+| [sia-reindex](skills/sia-reindex/SKILL.md) | Full tree-sitter re-walk | Large refactor; rename-heavy commits |
+| [sia-index](skills/sia-index/SKILL.md) | Index external content (markdown / URL) | Add docs, ADRs, meeting notes to the graph |
+| [sia-export-knowledge](skills/sia-export-knowledge/SKILL.md) | Human-readable KNOWLEDGE.md export | Team onboarding; stakeholder share |
+| [sia-export-import](skills/sia-export-import/SKILL.md) | Portable JSON export/import | Backup; migrate machine |
+
+### Development workflow
+
+| Skill | What it does | When to invoke |
+|---|---|---|
+| [sia-brainstorm](skills/sia-brainstorm/SKILL.md) | Design dialogue pre-loaded with graph context | Before any creative work |
+| [sia-plan](skills/sia-plan/SKILL.md) | Implementation plan writer with graph constraints | Spec → task breakdown |
+| [sia-execute](skills/sia-execute/SKILL.md) | Sandboxed code execution + indexing | Run scripts / snippets with SIA context |
+| [sia-execute-plan](skills/sia-execute-plan/SKILL.md) | Plan execution with staleness detection | Following an authored plan |
+| [sia-dispatch](skills/sia-dispatch/SKILL.md) | Parallel agent dispatch with independence checks | 2+ independent tasks |
+| [sia-debug-workflow](skills/sia-debug-workflow/SKILL.md) | Temporal debug workflow | Bug / test failure / regression |
+| [sia-test](skills/sia-test/SKILL.md) | Graph-informed TDD | Implementing with TDD; adding regression tests |
+| [sia-verify](skills/sia-verify/SKILL.md) | Verification gate with area-specific checks | Before claiming "done" |
+| [sia-review-respond](skills/sia-review-respond/SKILL.md) | Graph-backed code-review responses | PR comments arrive |
+| [sia-finish](skills/sia-finish/SKILL.md) | Branch finishing with semantic PR summaries | Branch ready to merge |
+| [sia-impact](skills/sia-impact/SKILL.md) | Pre-refactor impact analysis | Before rename / signature change |
+| [sia-learn](skills/sia-learn/SKILL.md) | (Also lives in Core) | See above |
+
+### Visualization & operations
+
+| Skill | What it does | When to invoke |
+|---|---|---|
+| [sia-visualize](skills/sia-visualize/SKILL.md) | Static HTML D3 graph | Shareable snapshot |
+| [sia-visualize-live](skills/sia-visualize-live/SKILL.md) | Live updating graph with filters | Interactive exploration |
+| [sia-doctor](skills/sia-doctor/SKILL.md) | System health diagnostics | Any MCP error; empty graph; post-upgrade |
+| [sia-stats](skills/sia-stats/SKILL.md) | Graph capacity / growth stats | Quick size check |
+| [sia-status](skills/sia-status/SKILL.md) | Health dashboard (capture rate, conflicts) | "Is SIA healthy?" |
+| [sia-upgrade](skills/sia-upgrade/SKILL.md) | Self-update via npm / git / binary | New release available |
+| [sia-workspace](skills/sia-workspace/SKILL.md) | Multi-repo workspace management | Cross-repo knowledge |
+| [sia-team](skills/sia-team/SKILL.md) | Team sync server join / leave / status | Team-sync configuration |
+| [sia-sync](skills/sia-sync/SKILL.md) | Manual push / pull of team knowledge | Mid-session re-sync |
+
+### Team / PM
+
+| Skill | What it does | When to invoke |
+|---|---|---|
+| [sia-pm-decision-log](skills/sia-pm-decision-log/SKILL.md) | Formal decision log | Stakeholder review; audit |
+| [sia-pm-risk-dashboard](skills/sia-pm-risk-dashboard/SKILL.md) | Technical risk assessment | Sprint planning; pre-release |
+| [sia-pm-sprint-summary](skills/sia-pm-sprint-summary/SKILL.md) | PM-ready sprint summary | Sprint review; retro |
+
+### QA
+
+| Skill | What it does | When to invoke |
+|---|---|---|
+| [sia-qa-coverage](skills/sia-qa-coverage/SKILL.md) | Coverage-gap analysis | Pre-release; test-improvement sprint |
+| [sia-qa-flaky](skills/sia-qa-flaky/SKILL.md) | Flaky test pattern miner | CI flake triage |
+| [sia-qa-report](skills/sia-qa-report/SKILL.md) | Risk-based QA report | QA cycle kickoff |
+
+## Agents (23)
+
+Agents are dispatched via `@sia-<name>` or their corresponding `/<name>` command. Each agent is self-contained with a `whenToUse` section, examples, and tools list.
+
+| Agent | What it does | When to dispatch |
+|---|---|---|
+| [sia-changelog-writer](agents/sia-changelog-writer.md) | Generates changelogs and release notes from the graph | Release prep |
+| [sia-code-reviewer](agents/sia-code-reviewer.md) | Code review with historical + convention context | PR review; pre-merge check |
+| [sia-conflict-resolver](agents/sia-conflict-resolver.md) | Walks through conflicting entities and applies chosen resolution | Conflicts exist in the graph |
+| [sia-convention-enforcer](agents/sia-convention-enforcer.md) | Scans diff against active Conventions | Lightweight pre-commit check |
+| [sia-debug-specialist](agents/sia-debug-specialist.md) | Temporal root-cause investigation | Active bug investigation |
+| [sia-decision-reviewer](agents/sia-decision-reviewer.md) | Past decisions, rejected approaches, active constraints | Before a new architectural choice |
+| [sia-dependency-tracker](agents/sia-dependency-tracker.md) | Cross-repo dependency and API-contract monitor | Workspace-level changes |
+| [sia-explain](agents/sia-explain.md) | Explains SIA itself — entities, tools, skills, agents | User learning the plugin |
+| [sia-feature](agents/sia-feature.md) | Feature development with architectural context | New feature work |
+| [sia-knowledge-capture](agents/sia-knowledge-capture.md) | Systematic uncaptured-knowledge extraction from session | End of session |
+| [sia-lead-architecture-advisor](agents/sia-lead-architecture-advisor.md) | Architecture drift detection | Leadership review |
+| [sia-lead-team-health](agents/sia-lead-team-health.md) | Knowledge distribution, bus-factor, capture trends | Team-health check |
+| [sia-migration](agents/sia-migration.md) | Graph updates during major refactor | Rename/restructure waves |
+| [sia-onboarding](agents/sia-onboarding.md) | Full multi-topic onboarding session | New team member |
+| [sia-orientation](agents/sia-orientation.md) | Quick single-answer architecture Q&A | "Why was X chosen?" |
+| [sia-pm-briefing](agents/sia-pm-briefing.md) | Plain-language PM project briefings | Status update for non-engineers |
+| [sia-pm-risk-advisor](agents/sia-pm-risk-advisor.md) | Technical risk surfaced in business-impact language | PM risk review |
+| [sia-qa-analyst](agents/sia-qa-analyst.md) | QA intelligence — risk, coverage, recommendations | QA cycle prep |
+| [sia-qa-regression-map](agents/sia-qa-regression-map.md) | Scored regression risk table per module | Test prioritisation |
+| [sia-refactor](agents/sia-refactor.md) | Dependency-graph impact analysis | Before structural refactor |
+| [sia-regression](agents/sia-regression.md) | Regression-risk assessment of proposed changes | PR / change risk review |
+| [sia-security-audit](agents/sia-security-audit.md) | Security review with paranoid mode and Tier 4 exposure | Security review |
+| [sia-test-advisor](agents/sia-test-advisor.md) | Test strategy from past failures + edge cases | Test-planning session |
+
+## Commands (non-shim)
+
+Most commands are thin shims that forward to a skill (`Run the /sia-X skill`) or dispatch an agent (`Dispatch the @sia-Y agent`). The ones below have substantive bodies worth reading directly:
+
+### Direct MCP wrappers
+
+| Command | What it does |
+|---|---|
+| [/at-time](commands/at-time.md) | Query graph state at a past timestamp |
+| [/community](commands/community.md) | Inspect community partitioning at a level |
+| [/freshness](commands/freshness.md) | Run the freshness engine |
+
+### Nous cognitive layer
+
+| Command | What it does |
+|---|---|
+| [/nous-state](commands/nous-state.md) | Current drift, preferences, recent signals |
+| [/nous-reflect](commands/nous-reflect.md) | Per-preference alignment breakdown + action |
+| [/nous-curiosity](commands/nous-curiosity.md) | Explore under-retrieved high-trust knowledge |
+| [/nous-concern](commands/nous-concern.md) | Surface open Concern nodes as prioritised insights |
+| [/nous-modify](commands/nous-modify.md) | Create / update / deprecate a Preference node (always requires a reason) |
+
+### Agent-delegation commands
+
+The remaining non-shim commands dispatch agents. Each has a one-line summary of the agent plus a link to its full definition — see `commands/*.md`. The full agent list is in the Agents table above.
+
+---
+
+## Regeneration
+
+This file is authored by hand for 1.1.7 but should be regenerated from skill/agent/command frontmatter + Usage sections in future releases. A `scripts/generate-plugin-usage.sh` template is included for that purpose. Run it with `--verify` to diff the generated output against this file (used by the Phase 6 validator).
+
+```bash
+bash scripts/generate-plugin-usage.sh            # prints regenerated tables to stdout
+bash scripts/generate-plugin-usage.sh --verify   # exits non-zero if drift detected
+```

--- a/PLUGIN_USAGE.md
+++ b/PLUGIN_USAGE.md
@@ -42,7 +42,7 @@ Shortest path for a new user: `/sia-setup` → `/sia-tour` → start working nor
 
 | Skill | What it does | When to invoke |
 |---|---|---|
-| [sia-augment](skills/sia-augment/SKILL.md) | Proactive capture assist | After ambiguous "we're doing X now" moments |
+| [sia-augment](skills/sia-augment/SKILL.md) | Toggle auto-enrichment of Grep/Glob/Bash results with graph context | Silence noisy augmentation; debug PreToolUse hook behavior |
 | [sia-digest](skills/sia-digest/SKILL.md) | 24-hour knowledge digest | Start of workday; daily standup |
 | [sia-history](skills/sia-history/SKILL.md) | Temporal explore of graph evolution | "What decisions were made this week?" |
 | [sia-compare](skills/sia-compare/SKILL.md) | Diff graph state across two time points | Release retro; sprint audit |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ sia doctor                          # Health check
 /sia-visualize-live                 # Graph explorer in your browser
 ```
 
+### Full component usage
+
+See [PLUGIN_USAGE.md](PLUGIN_USAGE.md) for per-skill, per-agent, per-command usage guides with invocation triggers and worked examples.
+
 ### Running the Test Suite
 
 Always run tests via the `bun run` wrapper so vitest picks up the project

--- a/commands/at-time.md
+++ b/commands/at-time.md
@@ -2,4 +2,26 @@
 description: Query the graph's state at a past point in time.
 argument-hint: <ISO-8601 timestamp or natural-language date>
 ---
-Invoke the sia_at_time MCP tool with the given timestamp and present the graph state at that point.
+
+Invoke the `sia_at_time` MCP tool with the given timestamp and present the graph state at that point.
+
+### Usage
+
+**When to invoke:**
+- "What did we know before this broke?" — regression root-cause investigation
+- Auditing graph state at a release tag or incident time
+- Comparing current knowledge against a historical snapshot
+
+**Inputs:** `$ARGUMENTS` — ISO-8601 timestamp (`2026-03-15T12:00:00Z`) or a natural-language date (`"2 weeks ago"`, `"last Friday"`). Optional `entity_types` filter inside the MCP call.
+
+**Worked example:**
+
+```
+$ /at-time 2026-03-15T00:00:00Z
+[at-time] Graph state as of 2026-03-15T00:00:00Z
+  · Active entities: 2,198 (vs 2,431 today)
+  · Active conflicts: 4 (vs 1 today — 3 resolved since)
+  · Last Decision before cutoff: "Use Redis for rate limiting" (2026-02-14)
+```
+
+Always called by the regression playbook — see `reference-regression.md` for the full flow.

--- a/commands/changelog-writer.md
+++ b/commands/changelog-writer.md
@@ -2,4 +2,4 @@
 description: Generate changelogs and release notes from SIA's knowledge graph
 ---
 
-Use the `@sia-changelog-writer` agent. 
+Dispatch the `@sia-changelog-writer` agent. See [`agents/sia-changelog-writer.md`](../agents/sia-changelog-writer.md) — at a glance: pulls Decisions, Bugs fixed, features added, and Conventions established since a given date or tag and formats them as Keep-a-Changelog-style release notes.

--- a/commands/code-reviewer.md
+++ b/commands/code-reviewer.md
@@ -2,4 +2,4 @@
 description: Review code changes using SIA's knowledge graph for context and convention enforcement
 ---
 
-Use the `@sia-code-reviewer` agent. 
+Dispatch the `@sia-code-reviewer` agent. See [`agents/sia-code-reviewer.md`](../agents/sia-code-reviewer.md) — at a glance: reviews a diff or PR with historical context from the graph, enforces captured conventions, and flags regression risk against known Bug history.

--- a/commands/community.md
+++ b/commands/community.md
@@ -2,4 +2,29 @@
 description: Inspect community structure at a given hierarchy level.
 argument-hint: [level=1|2]
 ---
-Invoke the sia_community MCP tool at the given level and summarise the partitioning.
+
+Invoke the `sia_community` MCP tool at the given level and summarise the partitioning.
+
+### Usage
+
+**When to invoke:**
+- Orientation — "what are the major modules in this repo?"
+- Before dispatching parallel agents — communities = independent-enough-to-parallelise
+- Before a refactor — check module boundaries
+
+**Inputs:** `$ARGUMENTS` — community hierarchy level (`1` for top-level clusters, `2` for sub-communities). Default is `1` when omitted.
+
+**Worked example:**
+
+```
+$ /community 1
+[community] Level 1 partition: 6 communities
+  · api-gateway        (142 entities) — HTTP routing, middleware, rate-limit
+  · orders             (88)           — checkout, charge, refund
+  · docs-site          (61)           — marketing + API reference
+  · auth               (54)           — session, token rotation
+  · analytics          (39)           — event pipeline
+  · infra              (27)           — deploy scripts, CI config
+```
+
+For entity-scoped community lookup (find the community of a specific entity), use the `sia_community` MCP tool directly with `entity_id`.

--- a/commands/conflict-resolver.md
+++ b/commands/conflict-resolver.md
@@ -2,4 +2,4 @@
 description: Resolve conflicting knowledge in the graph — walk through evidence and choose
 ---
 
-Use the `@sia-conflict-resolver` agent. 
+Dispatch the `@sia-conflict-resolver` agent. See [`agents/sia-conflict-resolver.md`](../agents/sia-conflict-resolver.md) — at a glance: walks the developer through each active conflict group, presents the competing entities with provenance and timestamps, and applies the chosen resolution (keep one, invalidate others).

--- a/commands/convention-enforcer.md
+++ b/commands/convention-enforcer.md
@@ -2,4 +2,4 @@
 description: Check code changes against all known conventions and flag violations
 ---
 
-Use the `@sia-convention-enforcer` agent. 
+Dispatch the `@sia-convention-enforcer` agent. See [`agents/sia-convention-enforcer.md`](../agents/sia-convention-enforcer.md) — at a glance: scans the current diff against every active Convention entity and flags violations. Lighter than a full code review — focused purely on convention compliance.

--- a/commands/decision-reviewer.md
+++ b/commands/decision-reviewer.md
@@ -2,4 +2,4 @@
 description: Surface past architectural decisions, rejected approaches, and constraints
 ---
 
-Use the `@sia-decision-reviewer` agent. 
+Dispatch the `@sia-decision-reviewer` agent. See [`agents/sia-decision-reviewer.md`](../agents/sia-decision-reviewer.md) — at a glance: surfaces past architectural decisions in the target area, what was tried and rejected, and active constraints. Run before making a new architectural choice to avoid repeating failed approaches.

--- a/commands/dependency-tracker.md
+++ b/commands/dependency-tracker.md
@@ -2,4 +2,4 @@
 description: Monitor cross-repo dependencies and detect breaking API changes
 ---
 
-Use the `@sia-dependency-tracker` agent. 
+Dispatch the `@sia-dependency-tracker` agent. See [`agents/sia-dependency-tracker.md`](../agents/sia-dependency-tracker.md) — at a glance: monitors cross-repo and cross-package dependencies via bridge edges, flags API contract changes, and detects breaking changes that cross repo boundaries in a workspace.

--- a/commands/explain.md
+++ b/commands/explain.md
@@ -2,4 +2,4 @@
 description: Understand SIA's knowledge graph — entity types, tools, skills, and agents
 ---
 
-Use the `@sia-explain` agent. 
+Dispatch the `@sia-explain` agent. See [`agents/sia-explain.md`](../agents/sia-explain.md) — at a glance: explains SIA itself — graph structure, entity types, edge relationships, trust tiers, and which tool/skill/agent to reach for in a given situation. Use when the developer is learning the plugin.

--- a/commands/feature.md
+++ b/commands/feature.md
@@ -2,4 +2,4 @@
 description: Feature development with architectural context and convention compliance
 ---
 
-Use the `@sia-feature` agent. 
+Dispatch the `@sia-feature` agent. See [`agents/sia-feature.md`](../agents/sia-feature.md) — at a glance: assists with feature development by pre-loading architectural context, dependency awareness, and convention compliance checks from the graph.

--- a/commands/knowledge-capture.md
+++ b/commands/knowledge-capture.md
@@ -2,4 +2,4 @@
 description: Systematically capture uncaptured knowledge from this session
 ---
 
-Use the `@sia-knowledge-capture` agent. 
+Dispatch the `@sia-knowledge-capture` agent. See [`agents/sia-knowledge-capture.md`](../agents/sia-knowledge-capture.md) — at a glance: reviews the current session's work, extracts Decisions / Conventions / Bugs / Solutions that were made or discovered, and writes each via `sia_note` after developer confirmation.

--- a/commands/lead-architecture-advisor.md
+++ b/commands/lead-architecture-advisor.md
@@ -2,4 +2,4 @@
 description: Detect architecture drift against captured decisions
 ---
 
-Use the `@sia-lead-architecture-advisor` agent. 
+Dispatch the `@sia-lead-architecture-advisor` agent. See [`agents/sia-lead-architecture-advisor.md`](../agents/sia-lead-architecture-advisor.md) — at a glance: compares current code structure against captured Decision entities and surfaces modules where the codebase has drifted from intended design.

--- a/commands/lead-team-health.md
+++ b/commands/lead-team-health.md
@@ -2,4 +2,4 @@
 description: Analyze team knowledge health — coverage gaps and bus-factor risks
 ---
 
-Use the `@sia-lead-team-health` agent. 
+Dispatch the `@sia-lead-team-health` agent. See [`agents/sia-lead-team-health.md`](../agents/sia-lead-team-health.md) — at a glance: analyses knowledge distribution across modules, flags coverage gaps, tracks convention compliance and capture rate trends, and identifies bus-factor risks (knowledge concentrated in one person).

--- a/commands/migration.md
+++ b/commands/migration.md
@@ -2,4 +2,4 @@
 description: Plan and execute knowledge graph updates during major refactoring
 ---
 
-Use the `@sia-migration` agent. 
+Dispatch the `@sia-migration` agent. See [`agents/sia-migration.md`](../agents/sia-migration.md) — at a glance: plans and executes graph updates during major refactoring — renames entities, rewires edges, invalidates stale knowledge, and cleans graph data after an architecture change.

--- a/commands/nous-concern.md
+++ b/commands/nous-concern.md
@@ -12,3 +12,17 @@ nous_concern({ context: "$ARGUMENTS" })
 Use this before responding to open-ended "what should I look at?" or "what am I missing?" questions. Concerns are filtered against active Preference nodes so the results are weighted by what the developer currently cares about.
 
 Present the top Concerns with their priority and summary. Suggest one or two as candidates to act on.
+
+### Worked example
+
+User: "what should I be watching out for in the payments module?"
+
+```
+$ /nous-concern "payments module"
+[concern] 3 open Concerns, weighted by active preferences:
+  1. [HIGH] "Idempotency key rotation missed on refund path" — Bug from 2 sprints ago, no regression test captured
+  2. [MED]  "Charge retry logic duplicates effects under clock skew" — Decision superseded but not invalidated
+  3. [LOW]  "Stripe webhook validation uses deprecated signature v1"
+```
+
+Suggest acting on #1 first — it's a captured Bug without a regression test, which matches the "Verify before claim" active preference.

--- a/commands/nous-curiosity.md
+++ b/commands/nous-curiosity.md
@@ -12,3 +12,15 @@ nous_curiosity({ topic: "$ARGUMENTS" })
 Curiosity explores the graph for high-trust entities that have never been retrieved and writes them as open Concern nodes. Use when a task completes with remaining capacity or a knowledge gap becomes visible.
 
 Summarise what was discovered and which Concerns were created.
+
+### Worked example
+
+```
+$ /nous-curiosity "auth module"
+[curiosity] scanned 142 high-trust auth entities
+[curiosity] 3 have never been retrieved across all sessions:
+  · Decision: "Session tokens must rotate on privilege elevation"
+  · Convention: "All auth logs tagged with trace_id"
+  · Bug: "Fixed CSRF bypass — regression test in test/auth/csrf.spec.ts"
+[curiosity] Created 3 Concern nodes (priority: medium, low, low).
+```

--- a/commands/nous-modify.md
+++ b/commands/nous-modify.md
@@ -17,3 +17,22 @@ nous_modify({ action: "create" | "update" | "deprecate", preference: { ... }, re
 - Blocked for subagents and when drift > 0.90.
 
 If the developer has not supplied a clear reason, ask them for one before calling the tool.
+
+### Worked example
+
+During a session the user says: "From now on we never mock the database in integration tests — we got burned last quarter when a mock hid a broken migration."
+
+```
+nous_modify({
+  action: "create",
+  preference: {
+    kind: "Convention",
+    name: "Never mock database in integration tests",
+    tier: 1
+  },
+  reason: "User 2026-04-21: prior incident where mock/prod divergence masked a broken migration in Q1. Persist across all future sessions."
+})
+// → { confirmationRequired: true, preference_id: "pref-4f2c" }
+```
+
+Tier 1 preferences require explicit developer confirmation; present the draft and wait for approval before re-calling with `confirm: true`.

--- a/commands/nous-reflect.md
+++ b/commands/nous-reflect.md
@@ -16,3 +16,17 @@ Present the response:
 - Recommended action (`continue`, `pause`, `escalate`)
 
 If `recommendedAction` is `escalate`, surface the drift breakdown verbatim and wait for developer input before proceeding.
+
+### Worked example
+
+```
+$ /nous-reflect "about to approve a big refactor PR"
+[nous] overall drift: 0.78 (above 0.70 warning)
+[nous] per-preference alignment:
+  · "YAGNI ruthlessly" — 0.91 (aligned)
+  · "Verify before claim" — 0.44 (drifting — 2 recent "looks good" without command output)
+  · "Never mock DB in tests" — 0.88 (aligned)
+[nous] recommendedAction: escalate
+```
+
+Surface the breakdown to the developer before continuing with the PR decision.

--- a/commands/nous-state.md
+++ b/commands/nous-state.md
@@ -10,3 +10,17 @@ Call the `nous_state` MCP tool with no arguments. Summarise:
 - Any open Concern nodes the user should know about
 
 Keep the summary under ~10 lines. If drift is high, recommend running `/nous-reflect` next.
+
+### Worked example
+
+```
+$ /nous-state
+[nous] drift: 0.42 (below 0.70 threshold)
+[nous] active preferences: 4 (T1: 2, T2: 2)
+  · Never mock DB in integration tests (T1)
+  · Use phase-named branches for new work (T1)
+  · Prefer Bun over Node (T2)
+  · Biome for lint/format (T2)
+[nous] recent signals: 1 surprise (low), 0 discomfort
+[nous] open concerns: 2 (run /nous-concern to see)
+```

--- a/commands/onboarding.md
+++ b/commands/onboarding.md
@@ -2,4 +2,4 @@
 description: Comprehensive onboarding session — architecture, conventions, decisions, issues
 ---
 
-Use the `@sia-onboarding` agent. 
+Dispatch the `@sia-onboarding` agent. See [`agents/sia-onboarding.md`](../agents/sia-onboarding.md) — at a glance: runs a full multi-topic onboarding session for a new team member covering architecture, conventions, decisions, known issues, and team context. Use `@sia-orientation` for quick single-answer questions instead.

--- a/commands/orientation.md
+++ b/commands/orientation.md
@@ -2,4 +2,4 @@
 description: Quick architecture Q&A — single focused answers from the graph
 ---
 
-Use the `@sia-orientation` agent. 
+Dispatch the `@sia-orientation` agent. See [`agents/sia-orientation.md`](../agents/sia-orientation.md) — at a glance: answers a single focused architecture question — "why was X chosen?", "how does Y work?", "what are the conventions for Z?" — using the graph. Quick Q&A, not a full onboarding.

--- a/commands/pm-briefing.md
+++ b/commands/pm-briefing.md
@@ -2,4 +2,4 @@
 description: Generate plain-language project briefings for project managers
 ---
 
-Use the `@sia-pm-briefing` agent. 
+Dispatch the `@sia-pm-briefing` agent. See [`agents/sia-pm-briefing.md`](../agents/sia-pm-briefing.md) — at a glance: generates plain-language project briefings for PMs — progress updates, decision summaries, risk areas, team activity. Works for both technical and non-technical PM audiences.

--- a/commands/pm-risk-advisor.md
+++ b/commands/pm-risk-advisor.md
@@ -2,4 +2,4 @@
 description: Technical risk advisor for PMs — debt, fragile modules, dependency risks
 ---
 
-Use the `@sia-pm-risk-advisor` agent. 
+Dispatch the `@sia-pm-risk-advisor` agent. See [`agents/sia-pm-risk-advisor.md`](../agents/sia-pm-risk-advisor.md) — at a glance: surfaces technical debt, recurring bugs, fragile modules, and dependency risks from the graph and translates them into business-impact language for PM audiences.

--- a/commands/qa-analyst.md
+++ b/commands/qa-analyst.md
@@ -2,4 +2,4 @@
 description: QA intelligence — regression risks, coverage gaps, test recommendations
 ---
 
-Use the `@sia-qa-analyst` agent. 
+Dispatch the `@sia-qa-analyst` agent. See [`agents/sia-qa-analyst.md`](../agents/sia-qa-analyst.md) — at a glance: QA intelligence agent — identifies regression risk areas, coverage gaps, recently changed modules, and produces test recommendations for QA and SDET teams.

--- a/commands/qa-regression-map.md
+++ b/commands/qa-regression-map.md
@@ -2,4 +2,4 @@
 description: Generate scored regression risk map (0-100) per module
 ---
 
-Use the `@sia-qa-regression-map` agent. 
+Dispatch the `@sia-qa-regression-map` agent. See [`agents/sia-qa-regression-map.md`](../agents/sia-qa-regression-map.md) — at a glance: produces a single ranked table with numeric risk ratings (0-100) per module by combining bug density, change velocity, and dependency fan-out. Optimised for test prioritisation decisions.

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -2,4 +2,4 @@
 description: Analyze impact of structural code changes using the dependency graph
 ---
 
-Use the `@sia-refactor` agent. 
+Dispatch the `@sia-refactor` agent. See [`agents/sia-refactor.md`](../agents/sia-refactor.md) — at a glance: analyses the dependency graph to map what calls, imports, and depends on the code you're about to change, plus relevant conventions — run before any structural refactor.

--- a/commands/regression.md
+++ b/commands/regression.md
@@ -2,4 +2,4 @@
 description: Analyze code changes for regression risk using the knowledge graph
 ---
 
-Use the `@sia-regression` agent. 
+Dispatch the `@sia-regression` agent. See [`agents/sia-regression.md`](../agents/sia-regression.md) — at a glance: analyses code changes for regression risk by checking them against known Bug entities, fragile areas, and historical failure patterns in the graph.

--- a/commands/security-audit.md
+++ b/commands/security-audit.md
@@ -2,4 +2,4 @@
 description: Security review with paranoid mode and Tier 4 exposure tracking
 ---
 
-Use the `@sia-security-audit` agent. 
+Dispatch the `@sia-security-audit` agent. See [`agents/sia-security-audit.md`](../agents/sia-security-audit.md) — at a glance: reviews code for security vulnerabilities using paranoid-mode graph queries, Tier 4 exposure tracking, and the security-related entity history in the graph.

--- a/commands/test-advisor.md
+++ b/commands/test-advisor.md
@@ -2,4 +2,4 @@
 description: Test strategy advice from past failures, coverage gaps, and edge cases
 ---
 
-Use the `@sia-test-advisor` agent. 
+Dispatch the `@sia-test-advisor` agent. See [`agents/sia-test-advisor.md`](../agents/sia-test-advisor.md) — at a glance: advises on test strategy using past test failures, known edge cases from Bug entities, coverage gaps, and project-specific test conventions from the graph.

--- a/scripts/generate-plugin-usage.sh
+++ b/scripts/generate-plugin-usage.sh
@@ -54,8 +54,8 @@ extract_usage_hint() {
 print_skills_table() {
   echo "## Skills"
   echo
-  echo "| Skill | What it does |"
-  echo "|---|---|"
+  echo "| Skill | What it does | When to invoke |"
+  echo "|---|---|---|"
   for dir in skills/*/; do
     local name
     name=$(basename "$dir")
@@ -69,7 +69,9 @@ print_skills_table() {
     # Strip the "Use when..." tail for the summary table.
     desc="${desc%%. Use when*}"
     desc="${desc%%. Called automatically*}"
-    echo "| [$name]($skill_file) | $desc |"
+    local hint
+    hint=$(extract_usage_hint "$skill_file")
+    echo "| [$name]($skill_file) | $desc | $hint |"
   done
 }
 
@@ -77,8 +79,8 @@ print_agents_table() {
   echo
   echo "## Agents"
   echo
-  echo "| Agent | What it does |"
-  echo "|---|---|"
+  echo "| Agent | What it does | When to invoke |"
+  echo "|---|---|---|"
   for f in agents/*.md; do
     [[ -f "$f" ]] || continue
     local name
@@ -87,7 +89,9 @@ print_agents_table() {
     desc=$(extract_description "$f")
     desc="${desc%%. Use when*}"
     desc="${desc%%. Works for*}"
-    echo "| [$name]($f) | $desc |"
+    local hint
+    hint=$(extract_usage_hint "$f")
+    echo "| [$name]($f) | $desc | $hint |"
   done
 }
 
@@ -95,8 +99,8 @@ print_commands_table() {
   echo
   echo "## Commands"
   echo
-  echo "| Command | Description | Kind |"
-  echo "|---|---|---|"
+  echo "| Command | Description | Kind | When to invoke |"
+  echo "|---|---|---|---|"
   for f in commands/*.md; do
     [[ -f "$f" ]] || continue
     local name
@@ -112,7 +116,9 @@ print_commands_table() {
     elif grep -qE '^(Invoke|Call) the `(sia|nous)_' "$f"; then
       kind="mcp-wrapper"
     fi
-    echo "| /$name | $desc | $kind |"
+    local hint
+    hint=$(extract_usage_hint "$f")
+    echo "| /$name | $desc | $kind | $hint |"
   done
 }
 
@@ -141,14 +147,16 @@ if [[ "$MODE" == "verify" ]]; then
   missing=0
   for dir in skills/*/; do
     name=$(basename "$dir")
-    if ! grep -q "$name" "$target"; then
+    # Use word-boundary match so e.g. future skill 'sia-at' does not pass
+    # verify via a substring match inside 'sia-at-time'.
+    if ! grep -Eq "(^|[^A-Za-z0-9_-])${name}([^A-Za-z0-9_-]|$)" "$target"; then
       echo "drift: skill '$name' not listed in $target" >&2
       missing=$((missing + 1))
     fi
   done
   for f in agents/*.md; do
     name=$(basename "$f" .md)
-    if ! grep -q "$name" "$target"; then
+    if ! grep -Eq "(^|[^A-Za-z0-9_-])${name}([^A-Za-z0-9_-]|$)" "$target"; then
       echo "drift: agent '$name' not listed in $target" >&2
       missing=$((missing + 1))
     fi

--- a/scripts/generate-plugin-usage.sh
+++ b/scripts/generate-plugin-usage.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Regenerate PLUGIN_USAGE.md tables from the frontmatter `description:` and
+# the first non-heading line of the Usage section in each SKILL / agent /
+# command. The output is deliberately simpler than the hand-authored file
+# (flat tables, no category grouping) so the Phase 6 validator can diff the
+# two and detect drift.
+#
+# Usage:
+#   bash scripts/generate-plugin-usage.sh           # print to stdout
+#   bash scripts/generate-plugin-usage.sh --verify  # exit non-zero on drift
+#
+# Note: this generator is intentionally simple for v1.1.7. It is a starting
+# point — the Phase 6 validator may tighten the contract (e.g. require every
+# skill/agent/command to have a parseable Usage section).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="print"
+if [[ "${1:-}" == "--verify" ]]; then
+  MODE="verify"
+fi
+
+# Extract the frontmatter `description:` field from a given file. Returns
+# the raw value (quotes stripped, trailing whitespace trimmed) or empty.
+extract_description() {
+  local file="$1"
+  awk '
+    /^---[[:space:]]*$/ { in_fm = !in_fm; next }
+    in_fm && /^description:/ {
+      sub(/^description:[[:space:]]*/, "")
+      sub(/^"/, ""); sub(/"[[:space:]]*$/, "")
+      sub(/^'\''/, ""); sub(/'\''[[:space:]]*$/, "")
+      print
+      exit
+    }
+  ' "$file"
+}
+
+# Extract the first non-heading line after any "Usage" / "When To Use"
+# / "How It Works" section heading. Returns empty if no such section.
+extract_usage_hint() {
+  local file="$1"
+  awk '
+    BEGIN { in_usage = 0 }
+    /^##[[:space:]]+(Usage|When To Use|When to use|How It Works|How it works)/ { in_usage = 1; next }
+    /^##[[:space:]]/ { in_usage = 0 }
+    in_usage && NF > 0 && $0 !~ /^[[:space:]]*(#|-|\*|```|\|)/ {
+      print
+      exit
+    }
+  ' "$file"
+}
+
+print_skills_table() {
+  echo "## Skills"
+  echo
+  echo "| Skill | What it does |"
+  echo "|---|---|"
+  for dir in skills/*/; do
+    local name
+    name=$(basename "$dir")
+    # Strip any trailing slash on $dir before appending SKILL.md so we don't
+    # emit //SKILL.md.
+    local clean="${dir%/}"
+    local skill_file="${clean}/SKILL.md"
+    [[ -f "$skill_file" ]] || continue
+    local desc
+    desc=$(extract_description "$skill_file")
+    # Strip the "Use when..." tail for the summary table.
+    desc="${desc%%. Use when*}"
+    desc="${desc%%. Called automatically*}"
+    echo "| [$name]($skill_file) | $desc |"
+  done
+}
+
+print_agents_table() {
+  echo
+  echo "## Agents"
+  echo
+  echo "| Agent | What it does |"
+  echo "|---|---|"
+  for f in agents/*.md; do
+    [[ -f "$f" ]] || continue
+    local name
+    name=$(basename "$f" .md)
+    local desc
+    desc=$(extract_description "$f")
+    desc="${desc%%. Use when*}"
+    desc="${desc%%. Works for*}"
+    echo "| [$name]($f) | $desc |"
+  done
+}
+
+print_commands_table() {
+  echo
+  echo "## Commands"
+  echo
+  echo "| Command | Description | Kind |"
+  echo "|---|---|---|"
+  for f in commands/*.md; do
+    [[ -f "$f" ]] || continue
+    local name
+    name=$(basename "$f" .md)
+    local desc
+    desc=$(extract_description "$f")
+    # Detect kind by grepping for the body pattern.
+    local kind="other"
+    if grep -qE '^Run the `/sia-' "$f"; then
+      kind="skill-shim"
+    elif grep -qE '^Dispatch the `@sia-' "$f"; then
+      kind="agent-delegation"
+    elif grep -qE '^(Invoke|Call) the `(sia|nous)_' "$f"; then
+      kind="mcp-wrapper"
+    fi
+    echo "| /$name | $desc | $kind |"
+  done
+}
+
+generate() {
+  echo "# Sia Plugin Usage — Generated"
+  echo
+  echo "_This file is machine-generated from skill / agent / command frontmatter. Do not hand-edit. Regenerate with \`bash scripts/generate-plugin-usage.sh\`._"
+  echo
+  print_skills_table
+  print_agents_table
+  print_commands_table
+}
+
+if [[ "$MODE" == "verify" ]]; then
+  # Drift detection: compare the generated tables against whatever is present
+  # in PLUGIN_USAGE.md. Since PLUGIN_USAGE.md is currently hand-authored and
+  # has a richer structure than the generator produces, the v1.1.7 verify
+  # mode is a coarse check: every skill / agent / non-shim command name must
+  # appear somewhere in PLUGIN_USAGE.md. Tighten in Phase 6 once hand-authoring
+  # is retired.
+  target="PLUGIN_USAGE.md"
+  if [[ ! -f "$target" ]]; then
+    echo "ERROR: $target not found" >&2
+    exit 2
+  fi
+  missing=0
+  for dir in skills/*/; do
+    name=$(basename "$dir")
+    if ! grep -q "$name" "$target"; then
+      echo "drift: skill '$name' not listed in $target" >&2
+      missing=$((missing + 1))
+    fi
+  done
+  for f in agents/*.md; do
+    name=$(basename "$f" .md)
+    if ! grep -q "$name" "$target"; then
+      echo "drift: agent '$name' not listed in $target" >&2
+      missing=$((missing + 1))
+    fi
+  done
+  if [[ "$missing" -gt 0 ]]; then
+    echo "drift detected: $missing component(s) missing from $target" >&2
+    exit 1
+  fi
+  echo "ok: all skills and agents appear in $target"
+  exit 0
+fi
+
+generate

--- a/skills/sia-brainstorm/SKILL.md
+++ b/skills/sia-brainstorm/SKILL.md
@@ -7,6 +7,17 @@ description: Brainstorms features using SIA's knowledge graph — surfaces past 
 
 Help turn ideas into fully formed designs and specs through natural collaborative dialogue, powered by SIA's knowledge graph. This improves upon standard brainstorming by starting with accumulated project knowledge instead of from scratch.
 
+## Usage
+
+**When to invoke:**
+- User starts any creative work — "I want to add X", "how should we design Y?"
+- Before touching code on a feature that needs shape
+- When revisiting a previously rejected approach and considering a retry
+
+**Inputs:** No arguments. The skill reads the idea from the user's message and drives a multi-round dialogue.
+
+**Worked example:** User: "I want to add a notifications panel." Skill first runs `sia_search({ query: "notifications panel", task_type: "feature" })` → finds a prior rejected design ("polling-based, caused N+1 load"); surfaces it up front ("you tried polling in Jan and rejected it — propose we go with a websocket push?"); proceeds to clarifying questions, then design, then spec doc at `docs/specs/YYYY-MM-DD-notifications-panel-design.md`.
+
 <HARD-GATE>
 Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
 </HARD-GATE>

--- a/skills/sia-compare/SKILL.md
+++ b/skills/sia-compare/SKILL.md
@@ -31,3 +31,12 @@ bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/index.ts compare --since 2026-03-01 --unti
 - "What knowledge was captured this sprint?"
 - "How much knowledge decayed in the last month?"
 - Before a knowledge audit — understand the graph's evolution
+
+## Worked Example
+
+```
+$ /sia-compare --since 2026-03-01 --until 2026-03-15
+Added (14): 4 Decisions, 3 Conventions, 5 Bugs, 2 Solutions
+Invalidated (3): "Use jQuery in docs-site" (superseded 2026-03-08), ...
+Archived (2): stale CodeSymbol entries below decay threshold
+```

--- a/skills/sia-conflicts/SKILL.md
+++ b/skills/sia-conflicts/SKILL.md
@@ -36,3 +36,14 @@ This:
 - When search results return contradictory information
 - After importing knowledge from another source
 - When conventions or decisions have been superseded
+
+## Worked Example
+
+```
+$ /sia-conflicts list
+group cg-4f2c: 2 entities
+  · ent-a1 "Session timeout = 15min" (Tier 1, captured 2026-01-12)
+  · ent-b7 "Session timeout = 60min" (Tier 2, captured 2026-03-04)
+$ /sia-conflicts resolve cg-4f2c ent-b7
+[conflicts] Kept ent-b7. Invalidated ent-a1 (t_valid_until=2026-04-21T...).
+```

--- a/skills/sia-debug-workflow/SKILL.md
+++ b/skills/sia-debug-workflow/SKILL.md
@@ -29,6 +29,18 @@ description: Debugs systematically using SIA's temporal knowledge graph — trac
 
 Debug methodically with SIA's temporal knowledge graph — adds temporal investigation ("when did it break?"), known bug history, and cross-session memory to standard debugging.
 
+## Usage
+
+**When to invoke:**
+- Bug reproduced, stack trace in hand, before investigating
+- Test failure or regression you don't immediately recognise
+- "It used to work" — always routes here (temporal investigation)
+- Error message appears to match a pattern you've seen before
+
+**Inputs:** No arguments. The skill drives `sia_search` / `sia_at_time` / `sia_by_file` MCP tools against the active repo.
+
+**Worked example:** User reports `TypeError: Cannot read property 'userId' of undefined in auth/session.ts`. Phase 1 runs `sia_search({ query: "userId undefined session", node_types: ["Bug", "Solution"] })` and returns a matching Bug + Solution pair from 6 weeks ago — the session object needed `requireAuth` middleware. Apply the known fix (5 minutes) instead of re-deriving it (2 hours).
+
 ## Checklist
 
 ```

--- a/skills/sia-digest/SKILL.md
+++ b/skills/sia-digest/SKILL.md
@@ -7,15 +7,34 @@ description: Generates a daily knowledge digest summarizing recent decisions, bu
 
 Generate a summary of recent knowledge captured in the graph.
 
-## Steps
+## Usage
 
-Run the digest command:
+**When to invoke:**
+- Start of a workday — "what did I/the team capture yesterday?"
+- Daily standup prep
+- User asks "what changed recently?" / "what's new in the graph?"
+
+**Inputs:** No arguments. Defaults to a 24-hour window.
+
+**Worked example:**
 
 ```bash
-bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/commands/digest.ts
+$ bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/commands/digest.ts
+# SIA Digest — 2026-04-21
+## Decisions (2)
+- Use Redis for rate limiting (api-gateway)
+- Drop jQuery in favour of native fetch (docs-site)
+## Conventions (1)
+- All order tests seed via seedOrders() (orders module)
+## Bugs & Solutions (1 / 1)
+- Double-charge on payment retry → idempotency key fix
+## Hot areas
+- src/api/middleware.ts — 4 entity touches
 ```
 
-This produces a markdown summary including:
+## What It Shows
+
+A markdown summary covering:
 - Decisions made in the last 24 hours
 - New conventions established
 - Bugs discovered and solutions applied

--- a/skills/sia-dispatch/SKILL.md
+++ b/skills/sia-dispatch/SKILL.md
@@ -7,6 +7,17 @@ description: Dispatches parallel agents using SIA's community detection for inde
 
 Dispatch parallel agents with graph-powered independence verification and rich per-agent context extraction.
 
+## Usage
+
+**When to invoke:**
+- 2+ independent tasks you're considering running in parallel
+- Large refactor that could be split across subagents
+- Any dispatch decision where "are these actually independent?" matters
+
+**Inputs:** No arguments. The skill takes the set of proposed tasks from context.
+
+**Worked example:** Three tasks: (1) add metrics to `api/`, (2) rewrite `docs/README.md`, (3) refactor `api/auth.ts`. Skill runs `sia_community({ level: 0 })` → tasks 1 and 3 are both in the `api` community (must be sequential); task 2 is in `docs` (safe to parallelise with either). Output: dispatch task 2 in parallel with (task 1 → task 3). Per-agent context injected from `sia_search` for conventions + known bugs in each agent's domain.
+
 ## Checklist
 
 ```

--- a/skills/sia-doctor/SKILL.md
+++ b/skills/sia-doctor/SKILL.md
@@ -7,6 +7,28 @@ description: Runs SIA system health diagnostics — checks databases, providers,
 
 Run comprehensive diagnostics on the SIA installation.
 
+## Usage
+
+**When to invoke:**
+- `sia_search` or any MCP tool returns an error
+- Knowledge feels missing (empty results on mature repos)
+- User reports "SIA isn't working" / "hooks aren't firing"
+- After upgrade, before filing a bug report
+
+**Inputs:** No arguments required. Optional `checks` via the MCP tool — see below.
+
+**Worked example:**
+
+```
+$ /sia-doctor
+[sia-doctor] graph_integrity: OK (2,431 entities, 6,104 edges)
+[sia-doctor] fts5: OK
+[sia-doctor] vss: OK (768-dim vectors)
+[sia-doctor] onnx: OK (bge-small-en-v1.5)
+[sia-doctor] runtimes: WARN — bun 1.0.30 detected (<1.1 recommended)
+[sia-doctor] hooks: OK (9/9 registered)
+```
+
 ## Steps
 
 Run the doctor command:

--- a/skills/sia-execute-plan/SKILL.md
+++ b/skills/sia-execute-plan/SKILL.md
@@ -28,6 +28,17 @@ description: Executes implementation plans with SIA's staleness detection, per-t
 
 Execute plans with staleness detection, per-task convention injection, and session resumption from SIA's knowledge graph.
 
+## Usage
+
+**When to invoke:**
+- You have a written plan (from `/sia-plan` or hand-authored) to execute
+- Resuming execution mid-plan after a session break
+- Running through a task checklist that references files
+
+**Inputs:** No arguments. Reads the plan file path from context (or asks).
+
+**Worked example:** Plan `docs/plans/2026-04-10-rate-limit.md` referencing `src/api/middleware.ts`. Skill first runs `sia_by_file({ file_path: "src/api/middleware.ts" })` → entity last modified 2026-04-18 (AFTER the plan); warns "plan may be stale — middleware.ts has changed since the plan was written. Show diff?". After the user confirms the plan still applies, proceeds task-by-task, injecting per-task conventions via `sia_search`.
+
 ## Checklist
 
 ```

--- a/skills/sia-export-import/SKILL.md
+++ b/skills/sia-export-import/SKILL.md
@@ -7,6 +7,26 @@ description: Exports and imports SIA knowledge graphs as portable JSON for backu
 
 Export the knowledge graph to portable JSON or import from a previous export.
 
+## Usage
+
+**When to invoke:**
+- Backup before a destructive operation (prune, mass invalidation)
+- Migrating SIA between machines
+- Sharing a snapshot with a teammate who isn't on team-sync
+
+**Inputs:**
+- Export: `--output <path>` (default `graph-export.json`)
+- Import: `--input <path>` (required), `--mode merge|replace` (default `merge`)
+
+**Worked example:**
+
+```
+$ /sia-export-import export --output ~/backups/sia-2026-04-21.json
+[export] Wrote 2,431 entities, 6,104 edges, 6 communities (3.8MB)
+$ /sia-export-import import --input ~/backups/sia-2026-04-21.json --mode merge
+[import] Consolidated 2,431 entities (14 merged into existing, 2,417 new)
+```
+
 ## Export
 
 Serialize the active graph (entities, edges, communities, cross-repo edges) to JSON:

--- a/skills/sia-export-knowledge/SKILL.md
+++ b/skills/sia-export-knowledge/SKILL.md
@@ -44,3 +44,12 @@ Each entry includes: date captured, trust tier (verified/code-derived/inferred/e
 - **External sharing** — generate a knowledge summary for stakeholders
 - **Backup** — human-readable export of the knowledge graph
 - **Documentation** — commit as living documentation alongside code
+
+## Worked Example
+
+```
+$ /sia-export-knowledge --output docs/project-knowledge.md --name "Acme Platform"
+[export-knowledge] Wrote docs/project-knowledge.md
+  · 24 Decisions · 18 Conventions · 12 Bugs · 10 Solutions · 6 Concepts
+  · Architecture section covers 6 communities
+```

--- a/skills/sia-finish/SKILL.md
+++ b/skills/sia-finish/SKILL.md
@@ -30,6 +30,17 @@ description: Finishes development branches using SIA — generates semantic PR s
 
 Finish a development branch with graph-powered semantic PR summaries and post-merge knowledge capture.
 
+## Usage
+
+**When to invoke:**
+- Feature/fix implementation is done and tests pass
+- User asks to "wrap up", "open a PR", or "finish the branch"
+- After the last commit on a dev branch, before merge
+
+**Inputs:** No arguments. Reads the current branch + SIA entities captured during the branch's lifetime.
+
+**Worked example:** On branch `feature/add-rate-limiting` with 4 commits. Skill runs `sia_search({ query: "rate limiting", limit: 20 })` → finds 2 Decisions and 1 Convention captured this branch; generates a PR body with `## Knowledge Captured` listing them; after merge runs `sia_note({ kind: "Decision", name: "Merged: add rate limiting" })` so future sessions see the branch-level summary.
+
 ## Checklist
 
 ```

--- a/skills/sia-freshness/SKILL.md
+++ b/skills/sia-freshness/SKILL.md
@@ -36,3 +36,14 @@ Additional metrics:
 - Before major refactoring to understand graph quality
 - When search results seem outdated
 - After `sia-prune` to confirm cleanup effectiveness
+
+## Worked Example
+
+```
+$ /sia-freshness
+[freshness] Fresh: 1,823 (74.9%) · Stale: 498 (20.5%) · Rotten: 110 (4.5%)
+[freshness] Pending revalidation: 37
+[freshness] Avg confidence — T1: 0.98 · T2: 0.92 · T3: 0.68 · T4: 0.54
+[freshness] Last deep validation: 2026-04-14 (7 days ago)
+[freshness] Native tree-sitter: yes
+```

--- a/skills/sia-history/SKILL.md
+++ b/skills/sia-history/SKILL.md
@@ -36,6 +36,16 @@ bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/index.ts history --file src/auth/login.ts
 - "What changed in the graph since last release?"
 - "What conventions were established recently?"
 
+## Worked Example
+
+```
+$ /sia-history --since 2026-04-14 --types Decision,Bug
+2026-04-16  Decision  Use Redis for rate limiting
+2026-04-17  Bug       Double-charge on payment retry
+2026-04-18  Decision  Drop jQuery from docs-site
+2026-04-20  Bug       Session timeout inconsistent across pods
+```
+
 ## Also Available
 
 - `sia_at_time` MCP tool — query the graph at a specific point in time

--- a/skills/sia-impact/SKILL.md
+++ b/skills/sia-impact/SKILL.md
@@ -68,3 +68,18 @@ Present the impact as a structured report:
 - Before changing a function's signature
 - Before splitting or merging modules
 - Before removing exports or APIs
+
+## Worked Example
+
+```
+$ /sia-impact processPayment
+[impact] entity: src/orders/charge.ts::processPayment (CodeEntity)
+[impact] incoming: 7 callers, 3 importers
+  · src/orders/checkout.ts:42 — calls
+  · src/api/webhooks.ts:18 — calls
+  · src/orders/refund.ts:91 — calls
+  · test/orders/charge.spec.ts — tests
+  ...
+[impact] conventions: 1 ("All charge paths must be idempotent")
+[impact] known bugs in this area: 2 — review before changing signature
+```

--- a/skills/sia-index/SKILL.md
+++ b/skills/sia-index/SKILL.md
@@ -7,6 +7,21 @@ description: Indexes external content into SIA's knowledge graph — markdown, U
 
 Index external content into the knowledge graph for future retrieval.
 
+## Usage
+
+**Inputs:** One of `content` (markdown/plain text) or `url`; optional `source`, `intent`, `tags`. See MCP tool blocks below.
+
+**Worked example:**
+
+```
+sia_index({
+  content: "# Rate limiting\nWe chose Redis over Postgres advisory locks for burst-load tolerance.",
+  source: "design-doc/rate-limiting-v2",
+  tags: ["decision", "api-gateway"]
+})
+// → ingested 1 chunk, extracted 2 candidate entities (1 Decision, 1 Concept)
+```
+
 ## When To Use
 
 Use this skill when you need to:

--- a/skills/sia-install/SKILL.md
+++ b/skills/sia-install/SKILL.md
@@ -7,6 +7,26 @@ description: Initializes SIA persistent memory in the current project — create
 
 Initialize SIA's persistent graph memory for the current project.
 
+## Usage
+
+**When to invoke:**
+- First-time SIA setup in a new repo
+- Adopting SIA on an existing repo that hasn't been indexed
+- Re-creating databases after an intentional reset
+
+**Inputs:** No arguments. Reads the current git repo from the working directory.
+
+**Worked example:**
+
+```bash
+$ /sia-install
+[install] Created graph.db, episodic.db
+[install] Registered repo 'sia' in meta.db (repo_id=r_4f2c)
+[install] Ready — run /sia-learn to populate the graph
+```
+
+Prefer `/sia-setup` for guided first-run (includes learn + tour). Use `/sia-install` only when you want the DB scaffold without indexing.
+
 ## What This Does
 
 1. Creates the SIA databases (graph.db, episodic.db) for this repository

--- a/skills/sia-learn/SKILL.md
+++ b/skills/sia-learn/SKILL.md
@@ -49,6 +49,20 @@ If the process crashes mid-run (OOM, Ctrl+C, power loss), re-running `/sia-learn
 - After a large refactoring
 - When onboarding to a new codebase
 
+## Worked Example
+
+```
+$ /sia-learn --incremental
+[sia] Indexing changed files (3)...
+[sia] Parsed src/auth/login.ts → 4 entities, 6 edges
+[sia] Parsed src/auth/session.ts → 2 entities, 3 edges
+[sia] Parsed docs/ADR-012-auth.md → 1 Decision
+[sia] Community re-cluster: 2 communities touched
+[sia] Done in 4.2s — 7 new entities, 9 new edges, 1 Decision
+```
+
+Subsequent `sia_search`, `sia_by_file`, and `sia_community` calls immediately see the new entities.
+
 ## After Learning
 
 Use SIA's MCP tools to query the knowledge graph:

--- a/skills/sia-plan/SKILL.md
+++ b/skills/sia-plan/SKILL.md
@@ -7,6 +7,17 @@ description: Writes implementation plans using SIA's knowledge of module topolog
 
 Write implementation plans pre-loaded with architectural constraints, module boundaries, and conventions from SIA's knowledge graph.
 
+## Usage
+
+**When to invoke:**
+- User hands you a spec and asks for a multi-step implementation plan
+- Breaking a large feature into tasks before executing
+- Coming out of `sia-brainstorm` with an approved design
+
+**Inputs:** No arguments. The skill reads the current spec / request from context, queries SIA for module boundaries, and emits a plan document.
+
+**Worked example:** Given spec "Add rate limiting to the public API", the skill runs `sia_community({ level: 1 })` (finds `api-gateway` and `shared-middleware` as separate communities → tasks can be parallel), `sia_search({ query: "rate limiting decisions", node_types: ["Decision"] })` (finds prior "use Redis for distributed counters" Decision), and writes a plan that respects both constraints. Output: a markdown plan with per-task graph citations.
+
 ## Checklist
 
 ```

--- a/skills/sia-playbooks/SKILL.md
+++ b/skills/sia-playbooks/SKILL.md
@@ -7,6 +7,17 @@ description: Load task-specific Sia playbooks (reference-regression, reference-f
 
 This skill provides detailed step-by-step guidance for using SIA's knowledge graph during specific task types. The CLAUDE.md behavioral spec directs you here after task classification.
 
+## Usage
+
+**When to invoke:**
+- CLAUDE.md Step 0 classifier points to a task type (bug-fix / feature / review / orientation)
+- You need the full MCP tool parameter reference (`reference-tools.md`)
+- Looking up flagging guidance (`reference-flagging.md`)
+
+**Inputs:** Reference filename passed inline in the skill invocation (e.g. `reference-regression.md`). No CLI arguments.
+
+**How it works:** Skill body below lists the available reference files and the load-on-demand pattern. The playbook file itself contains the step-by-step workflow for that task type.
+
 ## Available Playbooks
 
 Load the playbook matching your task type by reading the corresponding reference file in this skill's directory:

--- a/skills/sia-pm-decision-log/SKILL.md
+++ b/skills/sia-pm-decision-log/SKILL.md
@@ -9,8 +9,30 @@ Generate a formal decision log from the knowledge graph — useful for stakehold
 
 ## Usage
 
+**When to invoke:**
+- Stakeholder review / quarterly governance check
+- Onboarding a new team lead who needs the decision history
+- Audit trail needed for a compliance or post-mortem review
+
+**Inputs:**
+- `--since <date>` (optional, default 90 days ago): ISO date to filter Decision entities
+- `--until <date>` (optional, default today): ISO date upper bound
+- `--output <path>` (optional, default `DECISION-LOG.md`): target file
+
+**Worked example:**
+
 ```bash
 bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/index.ts pm-report --type decisions --since 2026-01-01
+```
+
+Produces `DECISION-LOG.md` with entries like:
+
+```markdown
+## 2026-02-14 — Use Redis for distributed rate limiting
+**Rationale:** Single-node counter doesn't survive pod restarts.
+**Alternatives considered:** Postgres advisory locks (rejected: lock contention under burst load).
+**Impact:** api-gateway, shared-middleware
+**Status:** Active
 ```
 
 ## Format

--- a/skills/sia-pm-risk-dashboard/SKILL.md
+++ b/skills/sia-pm-risk-dashboard/SKILL.md
@@ -9,8 +9,33 @@ Generate a technical risk assessment with business impact scoring.
 
 ## Usage
 
+**When to invoke:**
+- Sprint planning — "what's fragile and needs attention?"
+- After a production incident, to spot adjacent risk
+- PM-requested risk review before a big release
+
+**Inputs:**
+- `--output <path>` (optional, default `RISK-DASHBOARD.md`): target file
+- `--since <date>` (optional): only include bugs/conflicts seen after this date
+
+**Worked example:**
+
 ```bash
 bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/index.ts pm-report --type risks
+```
+
+Produces `RISK-DASHBOARD.md` with sections:
+
+```markdown
+### Critical
+- **payments/charge.ts** — 4 Bug entities in the last 60 days, 1 unresolved
+- **auth/session.ts** — conflict between 2 Decisions (session timeout policy)
+
+### Moderate
+- **api/rate-limit.ts** — high churn (12 commits in 30 days), no regression tests captured
+
+### Low
+- **docs/ADR-007** — stale Convention (superseded but not `t_valid_until`-closed)
 ```
 
 ## Risk Categories

--- a/skills/sia-pm-sprint-summary/SKILL.md
+++ b/skills/sia-pm-sprint-summary/SKILL.md
@@ -9,8 +9,36 @@ Generate a PM-ready sprint summary from the knowledge graph.
 
 ## Usage
 
+**When to invoke:**
+- Sprint review / retro prep
+- End-of-sprint status report for non-engineers
+- Weekly leadership briefing
+
+**Inputs:**
+- `--since <date>` (required): sprint start date
+- `--until <date>` (optional, default today): sprint end date
+- `--output <path>` (optional, default `SPRINT-SUMMARY.md`): target file
+
+**Worked example:**
+
 ```bash
 bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/index.ts pm-report --type sprint --since 2026-03-10 --until 2026-03-23
+```
+
+Produces `SPRINT-SUMMARY.md`:
+
+```markdown
+## Executive Summary
+Sprint 24 shipped the rate-limiting feature and resolved the payment-retry bug.
+
+## Key Decisions
+- **Use Redis for rate limiting** — chose over Postgres advisory locks for burst-load tolerance.
+
+## Bugs Found & Fixed
+- Double-charge on payment retry — root cause: missing idempotency key; fixed via `orders/charge.ts:42`.
+
+## Metrics
+- 14 entities captured · 8 Decisions · 3 Bugs · 3 Solutions
 ```
 
 ## Sections

--- a/skills/sia-prune/SKILL.md
+++ b/skills/sia-prune/SKILL.md
@@ -43,3 +43,15 @@ Pruning removes archived entities permanently. Invalidated entities are kept for
 - After `sia-freshness` identifies many rotten entities
 - As periodic maintenance (monthly recommended)
 - Before exporting the graph to reduce export size
+
+## Worked Example
+
+```
+$ /sia-prune --dry-run
+[prune] 87 archived entities eligible
+  · ent-12 "stale CodeSymbol parseToken" (importance 0.04, 184d idle)
+  · ent-34 "archived Convention (superseded twice)" (0.02, 220d idle)
+  ...
+$ /sia-prune --confirm
+[prune] Deleted 87 entities, reclaimed 3.2MB.
+```

--- a/skills/sia-qa-coverage/SKILL.md
+++ b/skills/sia-qa-coverage/SKILL.md
@@ -34,7 +34,7 @@ SIA cross-references:
 
 Areas with bugs but no corresponding test entities = coverage gaps.
 
-## Usage
+## Direct MCP queries
 
 Ask the sia-qa-analyst agent or run:
 

--- a/skills/sia-qa-coverage/SKILL.md
+++ b/skills/sia-qa-coverage/SKILL.md
@@ -7,6 +7,24 @@ description: Analyzes test coverage gaps using SIA's knowledge graph — finds b
 
 Identify areas that need more test coverage based on bug history and code changes.
 
+## Usage
+
+**When to invoke:**
+- Planning test-improvement sprint
+- Pre-release coverage audit
+- User asks "where are we under-tested?"
+
+**Inputs:** No arguments. Optionally scope via `--module <path>`.
+
+**Worked example:**
+
+```
+$ /sia-qa-coverage --module src/orders
+[coverage] 14 CodeEntities · 3 Bug entities · 1 dedicated test file
+[coverage] GAP: src/orders/refund.ts — 2 Bugs captured, no test entity
+[coverage] GAP: src/orders/checkout.ts — 1 Bug, partial test coverage
+```
+
 ## How It Works
 
 SIA cross-references:

--- a/skills/sia-qa-flaky/SKILL.md
+++ b/skills/sia-qa-flaky/SKILL.md
@@ -10,6 +10,25 @@ Identify flaky tests by mining SIA's bug history for patterns:
 - Tests where Bug → Solution → Bug again (fixed then broke again)
 - Areas with high Bug creation + invalidation churn
 
+## Usage
+
+**When to invoke:**
+- Triaging a CI that fails intermittently
+- "Which tests should we quarantine?" decisions
+- Post-release retro on test reliability
+
+**Inputs:** No arguments.
+
+**Worked example:**
+
+```
+$ /sia-qa-flaky
+[flaky] Top candidates (re-surfaced Bug entities):
+  · test/api/rate-limit.spec.ts → 4 Bugs across 3 months (fix → regression → fix → ...)
+  · test/orders/checkout.spec.ts → 2 Bugs, same assertion
+[flaky] Suggestion: quarantine rate-limit.spec.ts and re-investigate root cause.
+```
+
 ## How It Works
 
 ```

--- a/skills/sia-qa-report/SKILL.md
+++ b/skills/sia-qa-report/SKILL.md
@@ -9,9 +9,23 @@ Generate a testing-focused report from the knowledge graph.
 
 ## Usage
 
+**When to invoke:**
+- Kicking off a QA cycle — "what should we test first?"
+- Release readiness review
+- Risk-based testing prioritisation
+
+**Inputs:**
+- `--since <date>` (required): start of the reporting window
+- `--output <path>` (optional, default `QA-REPORT.md`)
+
+**Worked example:**
+
 ```bash
-bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/index.ts qa-report --since 2026-03-15
+$ bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/index.ts qa-report --since 2026-03-15
+[qa-report] Wrote QA-REPORT.md — 6 risk areas, 14 priority tests, 3 coverage gaps
 ```
+
+Produces a markdown report with sections: Changes since date, Risk assessment, Bug activity, Test recommendations, Coverage gaps.
 
 ## What It Shows
 

--- a/skills/sia-reindex/SKILL.md
+++ b/skills/sia-reindex/SKILL.md
@@ -7,6 +7,22 @@ description: Re-indexes the repository with tree-sitter to update SIA's knowledg
 
 Trigger a full or incremental re-index of the repository's code structure.
 
+## Usage
+
+**Inputs:** No arguments.
+
+**Worked example:**
+
+```
+$ /sia-reindex
+[reindex] Walked 1,204 files (skipped 87 via .gitignore)
+[reindex] Parsed with native tree-sitter: TypeScript, JS, Python, Go
+[reindex] Updated 2,431 CodeSymbol entities, 6,104 edges
+[reindex] Recomputed PageRank in 1.8s
+```
+
+Use `/sia-learn --incremental` for the faster changed-files-only path; `/sia-reindex` does a full walk.
+
 ## Steps
 
 Run the reindex command:

--- a/skills/sia-review-respond/SKILL.md
+++ b/skills/sia-review-respond/SKILL.md
@@ -7,6 +7,17 @@ description: Responds to code review feedback using SIA's knowledge of past deci
 
 Respond to code review feedback grounded in SIA's decision history, usage edges (YAGNI checks), and convention records — argue from the graph, not from memory.
 
+## Usage
+
+**When to invoke:**
+- PR review comments arrive, before you react to any of them
+- Reviewer suggests a pattern change you think has already been decided
+- Reviewer asks "why isn't this X?" and a prior Decision covers the answer
+
+**Inputs:** No arguments. The skill reads the review comments from context and cross-references them against the graph.
+
+**Worked example:** Reviewer comment: "Why aren't you using Zod for validation here?" Skill runs `sia_search({ query: "Zod validation decision", node_types: ["Decision"] })` → returns "Rejected Zod in favour of ajv — 2025-11 perf benchmark showed 3x overhead on hot path". Response drafted: "We evaluated Zod in November (see Decision ID xyz) and chose ajv for the hot-path perf reasons — happy to revisit if the workload has changed." Graph receipts, not memory.
+
 ## Checklist
 
 ```

--- a/skills/sia-stats/SKILL.md
+++ b/skills/sia-stats/SKILL.md
@@ -7,6 +7,17 @@ description: Shows SIA knowledge graph statistics — entity counts, edges, comm
 
 Display statistics about the project's knowledge graph.
 
+## Usage
+
+**When to invoke:**
+- Quick capacity / growth check
+- Answering "how big is my graph?" / "how much has SIA captured?"
+- Diagnosing why a `sia_search` returned sparse results (is the graph even populated?)
+
+**Inputs:** No arguments; optional `include_session: true` via the MCP tool.
+
+**Typical output:** An inline table of node counts by type, edge counts by kind, community count, database file sizes, and the timestamp of the most recent index run.
+
 ## Steps
 
 Run the stats command:

--- a/skills/sia-status/SKILL.md
+++ b/skills/sia-status/SKILL.md
@@ -7,6 +7,17 @@ description: Shows SIA knowledge graph health — entity counts by type and tier
 
 Display a health dashboard for the project's knowledge graph.
 
+## Usage
+
+**When to invoke:**
+- User asks "is SIA healthy?" / "how's my graph?"
+- Checking capture rate during a busy sprint
+- Quick conflict count — "do we have any unresolved conflicts?"
+
+**Inputs:** No arguments.
+
+**Typical output:** A dashboard with totals (entities, edges, communities, conflicts, archived), recent capture rate (24h), graph age, plus breakdowns by entity type and trust tier.
+
 ## Steps
 
 Run the status command:

--- a/skills/sia-sync/SKILL.md
+++ b/skills/sia-sync/SKILL.md
@@ -9,6 +9,23 @@ Manually trigger a push or pull of knowledge to/from the team sync server.
 
 Sync normally happens automatically (pull on session start, push on session end). Use this skill when you want to sync mid-session — for example, when you know a teammate just finished capturing important decisions.
 
+## Usage
+
+**When to invoke:**
+- Mid-session, when a teammate just captured something you need
+- After a long offline stretch — pull before starting
+- Before a presentation or review, to ensure you have the latest team knowledge
+
+**Inputs:** No arguments for the combined `sync`; `push` or `pull` as subcommands.
+
+**Worked example:**
+
+```
+$ /sia-sync
+[sync] Push: 5 entities, 12 edges, 0 bridge edges
+[sync] Pull: 3 entities, 8 edges, 2 VSS refreshed
+```
+
 ## Push Local Knowledge
 
 Push your locally captured knowledge to the team:

--- a/skills/sia-team/SKILL.md
+++ b/skills/sia-team/SKILL.md
@@ -7,6 +7,26 @@ description: Manages SIA team sync — joining servers, checking status, or leav
 
 Manage team-based knowledge graph synchronization. SIA syncs knowledge between team members via a self-hosted sqld (libSQL) server managed by your DevOps team.
 
+## Usage
+
+**When to invoke:**
+- First-time onboarding to a team sync server
+- Sync health check ("is my knowledge reaching the team?")
+- Leaving a project or rotating to a new team
+
+**Inputs:** Varies by subcommand — `join`, `status`, `leave`. See sections below.
+
+**Worked example:**
+
+```bash
+$ /sia-team join https://sia-sync.acme.corp eyJhbGciOi...
+[team] Token stored in keychain
+[team] Dev ID generated: dev-4f2c1b8a
+[team] Server reachable · libSQL replication enabled
+$ /sia-sync
+[sync] Pulled 142 entities, 318 edges from team server
+```
+
 ## Prerequisites
 
 Your DevOps team must have deployed a sqld sync server. You need:

--- a/skills/sia-test/SKILL.md
+++ b/skills/sia-test/SKILL.md
@@ -28,6 +28,17 @@ description: Guides test-driven development using SIA's knowledge of test conven
 
 TDD informed by SIA's knowledge graph — surfaces this project's test conventions, known edge cases from past bugs, and actual interface contracts before writing the first test.
 
+## Usage
+
+**When to invoke:**
+- Implementing a feature or bugfix TDD-style
+- Writing the first test for a module where conventions may exist
+- After a Bug entity was captured and a regression test is required
+
+**Inputs:** No arguments. The skill queries SIA for test conventions, known bugs, and the file entities under test.
+
+**Worked example:** Starting on `src/orders/checkout.ts`. Skill runs `sia_search({ query: "test conventions checkout orders", node_types: ["Convention"] })` → returns "All order tests use in-memory SQLite, seed with `seedOrders()`, assert on JSON shape"; then `sia_search({ query: "bugs checkout orders", node_types: ["Bug"] })` → returns two historical bugs (double-charge on retry, tax rounding). First test written covers both edge cases using the established convention — not a generic template.
+
 ## Checklist
 
 ```

--- a/skills/sia-tour/SKILL.md
+++ b/skills/sia-tour/SKILL.md
@@ -27,3 +27,19 @@ bun run ${CLAUDE_PLUGIN_ROOT}/src/cli/index.ts tour
 - When onboarding to a project — get the full picture
 - After a long break — refresh your memory of the project
 - When a new team member joins — share what SIA knows
+
+## Worked Example
+
+```
+$ /sia-tour
+[tour] Architecture: 6 communities
+  · api-gateway (142 entities) — HTTP routing, middleware
+  · orders (88) — checkout, charge, refund
+  · docs-site (61) — marketing + API reference
+  · auth (54) — session, session-store
+  · analytics (39) — event pipeline
+  · infra (27) — deploy scripts
+[tour] Key decisions (top 5): ...
+[tour] Active bugs: 2
+[tour] Run /sia-search <topic> to drill in.
+```

--- a/skills/sia-upgrade/SKILL.md
+++ b/skills/sia-upgrade/SKILL.md
@@ -7,6 +7,24 @@ description: Self-updates SIA to the latest version via npm, git, or binary stra
 
 Update SIA to the latest version.
 
+## Usage
+
+**When to invoke:**
+- A new SIA release is announced
+- CHANGELOG shows a fix you need
+- Regular maintenance (monthly)
+
+**Inputs:** Optional `target_version`; optional `dry_run`. See below.
+
+**Worked example:**
+
+```
+sia_upgrade({ dry_run: true })
+// → "Would upgrade 1.1.6 → 1.1.7 via npm; no breaking changes in release notes"
+sia_upgrade({})
+// → "Upgraded to 1.1.7. Run /sia-doctor to verify."
+```
+
 ## Quick Upgrade
 
 Use the `sia_upgrade` MCP tool:

--- a/skills/sia-verify/SKILL.md
+++ b/skills/sia-verify/SKILL.md
@@ -31,6 +31,17 @@ description: Verifies work completeness using SIA's knowledge of area-specific r
 
 Verify work is truly complete — queries SIA for area-specific requirements, past verification failures, and known gotchas before running checks. Evidence before assertions.
 
+## Usage
+
+**When to invoke:**
+- Before claiming "done" on any task
+- Before committing or opening a PR
+- After a bugfix, to ensure the known regression surface is covered
+
+**Inputs:** No arguments. The skill takes the area/files from context.
+
+**Worked example:** About to claim the rate-limiting feature is done. Skill queries `sia_search({ query: "verification requirements api-gateway", node_types: ["Convention"] })` → returns "api-gateway changes require integration tests AND typecheck". Runs both (`bun run test:int`, `bun run typecheck`), reads full output, confirms pass, then allows the "done" claim.
+
 ## Checklist
 
 ```

--- a/skills/sia-visualize/SKILL.md
+++ b/skills/sia-visualize/SKILL.md
@@ -7,6 +7,25 @@ description: Generates an interactive HTML visualization of the SIA knowledge gr
 
 Generate a D3.js force-directed graph visualization of the knowledge graph.
 
+## Usage
+
+**When to invoke:**
+- User wants a shareable static HTML view of the graph
+- Embedding a graph view in a doc or wiki
+- Quick offline inspection without the live server
+
+**Inputs:** No arguments.
+
+**Worked example:**
+
+```
+$ /sia-visualize
+[graph] Rendered 2,431 nodes, 6,104 edges → sia-graph.html (1.2MB)
+[graph] Open sia-graph.html in your browser
+```
+
+For a live updating view with filters use `/sia-visualize-live` instead.
+
 ## Steps
 
 1. Run the graph visualization command:

--- a/skills/sia-workspace/SKILL.md
+++ b/skills/sia-workspace/SKILL.md
@@ -7,6 +7,28 @@ description: Manages SIA workspaces for cross-repo knowledge sharing — creatin
 
 Manage workspaces that enable cross-repo knowledge sharing.
 
+## Usage
+
+**When to invoke:**
+- You're working across 2+ repos and want shared search
+- Setting up a monorepo-style knowledge view from separate repos
+- Tracking API contracts between backend and client repos
+
+**Inputs:** Subcommand (`create`, `list`, `add`, `remove`, `show`) plus name and path as positional args.
+
+**Worked example:**
+
+```
+$ /sia-workspace create acme-platform
+[workspace] Created 'acme-platform' (empty)
+$ /sia-workspace add acme-platform /Users/me/src/api
+$ /sia-workspace add acme-platform /Users/me/src/web
+$ /sia-workspace show acme-platform
+acme-platform: 2 repos, 4,812 entities, 12 bridge edges
+```
+
+Subsequent `sia_search({ workspace: true })` calls now span both repos.
+
 ## What Are Workspaces?
 
 Workspaces group multiple repositories together so SIA can:


### PR DESCRIPTION
## Summary

Phase 3 of the plugin polish plan. Every skill and command the plugin ships now has clear usage documentation, plus a new `PLUGIN_USAGE.md` at repo root that consolidates everything with links.

### Added

- **`PLUGIN_USAGE.md`** — consolidated per-skill, per-agent, per-command usage guide with invocation triggers and worked examples. Linked from README and PLUGIN_README.
- **Usage documentation on 38 skills** that were previously thin or missing it (audit-driven; already-documented skills were left alone). Individual skills keep their existing section structure (some use `## Usage`, others split into `## When To Use` + `## Worked Example`) — the contract is semantic: every skill covers what it does, when to invoke, inputs, and a worked example or typical output.
- **Context blurbs on 22 agent-delegation commands** so a user reading the command body understands what the underlying agent does without round-tripping.
- **Positive worked examples on 5 `/nous-*` commands** (previously safety-rules-only).
- **Full Usage sections on 2 direct-MCP commands** (`/at-time`, `/community`).
- **`scripts/generate-plugin-usage.sh`** — walks skills/agents/commands, regenerates PLUGIN_USAGE.md tables (includes "When to invoke" column). `--verify` does drift detection with word-boundary matching (so `sia-at` won't substring-match `sia-at-time`).

### Changed

- README and PLUGIN_README both link to `PLUGIN_USAGE.md` as the per-component discovery entry point.

## Test plan

- [x] `bun run test` — 2021/2021 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx @biomejs/biome check .` — 557 files, 0 errors
- [x] `bash scripts/generate-plugin-usage.sh --verify` — exit 0
- [x] `bash scripts/count-plugin-components.sh` — 47 / 23 / 71 / 29 / 9 / 7 (unchanged)
- [x] Drift test — manually renamed a skill in PLUGIN_USAGE.md; `--verify` correctly reports drift and exits 1
- [x] All 9 pre-existing well-documented skills (sia-augment, sia-capture, sia-nous, sia-search, sia-setup, sia-at-time, sia-community-inspect, sia-visualize-live, sia-execute) untouched by this PR
- [x] Zero `src/`, `agents/`, `hooks/`, `.mcp.json` changes

## Commits

- `a9ae9f6`–`71a5485` — skills Usage sections (5 batches by user-facing priority)
- `787c9e1` — 22 agent-delegation command blurbs
- `cce7542` — 5 nous-* + 2 MCP-wrapper command fixes
- `c675528` — PLUGIN_USAGE.md + generator
- `70e83a6` — version 1.1.7 + README links + CHANGELOG
- `04937e5` — post-review fixes (factual sia-augment row, duplicate heading in sia-qa-coverage, CHANGELOG softening, count correction, generator hardening)