### PR TITLE
chore(plugin): agent completeness (phase 4); v1.1.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.7"
+		"version": "1.1.8"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.7",
+			"version": "1.1.8",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.1.7"
+	"version": "1.1.8"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ All notable changes to Sia are documented here. This project adheres to
   body from the branch diff plus Decisions/Bugs/Solutions captured on
   this branch. Closes the most common missing-agent gap identified in
   the plugin audit.
-- `color:` declared on all 23 agents using a semantic palette
-  (red=regression, green=feature, cyan=review/audit, blue=orient/explain,
-  purple=plan/architecture, yellow=risk/security). Previously only 4
-  agents declared a color.
+- `color:` declared on all 24 agents using a semantic palette
+  (red=regression/incident, green=feature/create/generate,
+  cyan=review/audit, blue=orient/explain,
+  purple=plan/architecture/strategy). Previously only 4 agents
+  declared a color.
 
 ### Changed
 - Tool grants expanded on 7 agents whose stated purpose structurally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.1.8] - 2026-04-21
+
+### Added
+- New `sia-pr-writer` agent (+ `/pr-writer` command) that drafts a PR
+  body from the branch diff plus Decisions/Bugs/Solutions captured on
+  this branch. Closes the most common missing-agent gap identified in
+  the plugin audit.
+- `color:` declared on all 23 agents using a semantic palette
+  (red=regression, green=feature, cyan=review/audit, blue=orient/explain,
+  purple=plan/architecture, yellow=risk/security). Previously only 4
+  agents declared a color.
+
+### Changed
+- Tool grants expanded on 7 agents whose stated purpose structurally
+  required additional MCP tools:
+  - `sia-changelog-writer`: +`sia_at_time`, +`sia_backlinks`
+    (temporal "since last tag" + dependency-aware release notes)
+  - `sia-migration`: +`sia_backlinks`, +`sia_expand`, +`sia_ast_query`,
+    +`sia_impact` (cannot find references to renamed entities
+    without these)
+  - `sia-security-audit`: +`sia_at_time`, +`sia_flag`
+    (temporal security events + flagging)
+  - `sia-pm-risk-advisor`: +`sia_at_time`, +`sia_by_file`
+  - `sia-code-reviewer`: +`sia_at_time`
+  - `sia-convention-enforcer`: +`sia_by_file`
+  - `sia-conflict-resolver`: +`sia_at_time`, +`sia_flag`
+
 ## [1.1.7] - 2026-04-21
 
 ### Added

--- a/PLUGIN_USAGE.md
+++ b/PLUGIN_USAGE.md
@@ -103,7 +103,7 @@ Shortest path for a new user: `/sia-setup` → `/sia-tour` → start working nor
 | [sia-qa-flaky](skills/sia-qa-flaky/SKILL.md) | Flaky test pattern miner | CI flake triage |
 | [sia-qa-report](skills/sia-qa-report/SKILL.md) | Risk-based QA report | QA cycle kickoff |
 
-## Agents (23)
+## Agents (24)
 
 Agents are dispatched via `@sia-<name>` or their corresponding `/<name>` command. Each agent is self-contained with a `whenToUse` section, examples, and tools list.
 
@@ -126,6 +126,7 @@ Agents are dispatched via `@sia-<name>` or their corresponding `/<name>` command
 | [sia-orientation](agents/sia-orientation.md) | Quick single-answer architecture Q&A | "Why was X chosen?" |
 | [sia-pm-briefing](agents/sia-pm-briefing.md) | Plain-language PM project briefings | Status update for non-engineers |
 | [sia-pm-risk-advisor](agents/sia-pm-risk-advisor.md) | Technical risk surfaced in business-impact language | PM risk review |
+| [sia-pr-writer](agents/sia-pr-writer.md) | Drafts a PR body from branch diff + captured Decisions/Bugs/Solutions | Before `gh pr create`; PR body refresh |
 | [sia-qa-analyst](agents/sia-qa-analyst.md) | QA intelligence — risk, coverage, recommendations | QA cycle prep |
 | [sia-qa-regression-map](agents/sia-qa-regression-map.md) | Scored regression risk table per module | Test prioritisation |
 | [sia-refactor](agents/sia-refactor.md) | Dependency-graph impact analysis | Before structural refactor |

--- a/agents/sia-changelog-writer.md
+++ b/agents/sia-changelog-writer.md
@@ -16,7 +16,7 @@ whenToUse: |
   user: "What's changed since v2.0?"
   assistant: "Let me use the sia-changelog-writer to compile all changes from the graph."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__sia_search, mcp__sia__sia_at_time, mcp__sia__sia_backlinks
 ---
 
 # SIA Changelog Writer — Graph-Powered Release Notes

--- a/agents/sia-changelog-writer.md
+++ b/agents/sia-changelog-writer.md
@@ -2,6 +2,7 @@
 name: sia-changelog-writer
 description: Generates changelogs and release notes from SIA's knowledge graph — pulls decisions, bugs fixed, features added, and conventions established since a given date or tag
 model: sonnet
+color: green
 whenToUse: |
   Use when preparing a release, writing changelog entries, or generating release notes.
 

--- a/agents/sia-code-reviewer.md
+++ b/agents/sia-code-reviewer.md
@@ -3,7 +3,7 @@ name: sia-code-reviewer
 description: Reviews code changes using SIA's knowledge graph for historical context, convention enforcement, and regression detection
 model: sonnet
 color: cyan
-tools: Read, Grep, Glob, Bash, mcp__sia__nous_reflect, mcp__sia__nous_state, mcp__sia__sia_by_file, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__nous_reflect, mcp__sia__nous_state, mcp__sia__sia_by_file, mcp__sia__sia_note, mcp__sia__sia_search, mcp__sia__sia_at_time
 whenToUse: |
   Use when reviewing code changes, pull requests, or diffs. This agent retrieves project conventions, past decisions, and known bugs from SIA's knowledge graph to provide context-aware code review.
 

--- a/agents/sia-conflict-resolver.md
+++ b/agents/sia-conflict-resolver.md
@@ -16,7 +16,7 @@ whenToUse: |
   user: "After sync, there are conflicts in the auth module decisions."
   assistant: "Let me use the sia-conflict-resolver to review and resolve them."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_expand, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__sia_expand, mcp__sia__sia_note, mcp__sia__sia_search, mcp__sia__sia_at_time, mcp__sia__sia_flag
 ---
 
 # SIA Conflict Resolver — Knowledge Conflict Resolution

--- a/agents/sia-conflict-resolver.md
+++ b/agents/sia-conflict-resolver.md
@@ -2,6 +2,7 @@
 name: sia-conflict-resolver
 description: Guides resolution of conflicting knowledge in the graph — when two entities contradict each other, walks through evidence and helps the developer choose which is correct
 model: sonnet
+color: red
 whenToUse: |
   Use when SIA's search results return entities with conflict_group_id set, or when the user asks about contradictions in the knowledge graph.
 

--- a/agents/sia-convention-enforcer.md
+++ b/agents/sia-convention-enforcer.md
@@ -2,6 +2,7 @@
 name: sia-convention-enforcer
 description: Proactively checks code changes against all known conventions and flags violations — lighter than a full code review, focused purely on convention compliance
 model: sonnet
+color: cyan
 whenToUse: |
   Use when checking if recent changes follow project conventions, or when the user wants a quick convention check before committing.
 

--- a/agents/sia-convention-enforcer.md
+++ b/agents/sia-convention-enforcer.md
@@ -16,7 +16,7 @@ whenToUse: |
   user: "What's our convention for error handling in API routes?"
   assistant: "Let me use the sia-convention-enforcer to look up the relevant conventions."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__sia_note, mcp__sia__sia_search, mcp__sia__sia_by_file
 ---
 
 # SIA Convention Enforcer — Convention Compliance Agent

--- a/agents/sia-debug-specialist.md
+++ b/agents/sia-debug-specialist.md
@@ -2,6 +2,7 @@
 name: sia-debug-specialist
 description: Investigates active bugs using SIA's temporal knowledge graph — traces root cause through time, finds what changed and when, surfaces related known bugs and past solutions
 model: sonnet
+color: red
 whenToUse: |
   Use when actively debugging a bug, error, or unexpected behavior. This agent uses SIA's temporal queries to investigate what changed, when it broke, and what past bugs in the same area looked like.
 

--- a/agents/sia-decision-reviewer.md
+++ b/agents/sia-decision-reviewer.md
@@ -2,6 +2,7 @@
 name: sia-decision-reviewer
 description: Surfaces past architectural decisions, what was tried and rejected, and constraints in the same area — prevents repeating failed approaches before making new choices
 model: sonnet
+color: purple
 whenToUse: |
   Use when making an architectural or design decision, especially in an area where past decisions exist. This agent does "decision archaeology" — finding what was decided before, why, and what was rejected.
 

--- a/agents/sia-dependency-tracker.md
+++ b/agents/sia-dependency-tracker.md
@@ -2,6 +2,7 @@
 name: sia-dependency-tracker
 description: Monitors cross-repo and cross-package dependencies — surfaces API contract changes, detects breaking changes across repo boundaries, and tracks workspace-level relationships
 model: sonnet
+color: cyan
 whenToUse: |
   Use when working across repository boundaries, checking API contracts, or when changes in one repo might affect another.
 

--- a/agents/sia-explain.md
+++ b/agents/sia-explain.md
@@ -2,6 +2,7 @@
 name: sia-explain
 description: Helps users understand, query, and work with SIA's knowledge graph — explains graph structure, entity types, edge relationships, trust tiers, tools, skills, and agents
 model: sonnet
+color: blue
 whenToUse: |
   Use when the user asks about SIA itself — how it works, what tools are available, how to query the graph, what entity types mean, or how to get the most out of SIA.
 

--- a/agents/sia-knowledge-capture.md
+++ b/agents/sia-knowledge-capture.md
@@ -2,6 +2,7 @@
 name: sia-knowledge-capture
 description: Reviews the current session's work and systematically captures all uncaptured knowledge — decisions made, conventions discovered, bugs found, solutions applied
 model: sonnet
+color: green
 whenToUse: |
   Use at the end of a significant work session, or when the user wants to ensure important knowledge was captured. This agent reviews what happened and produces sia_note calls for anything missing.
 

--- a/agents/sia-lead-architecture-advisor.md
+++ b/agents/sia-lead-architecture-advisor.md
@@ -2,6 +2,7 @@
 name: sia-lead-architecture-advisor
 description: Detects architecture drift by comparing current code structure against captured architectural decisions — surfaces where the codebase has diverged from intended design
 model: sonnet
+color: purple
 whenToUse: |
   Use when a tech lead wants to verify the codebase still matches architectural decisions, or when reviewing whether the team is following the intended design.
 

--- a/agents/sia-lead-team-health.md
+++ b/agents/sia-lead-team-health.md
@@ -2,6 +2,7 @@
 name: sia-lead-team-health
 description: Analyzes team knowledge health — knowledge distribution across modules, coverage gaps, convention compliance, capture rate trends, and identifies areas where knowledge is concentrated in one person
 model: sonnet
+color: cyan
 whenToUse: |
   Use when a tech lead wants to understand team knowledge distribution, identify bus-factor risks, or assess overall knowledge health.
 

--- a/agents/sia-migration.md
+++ b/agents/sia-migration.md
@@ -2,6 +2,7 @@
 name: sia-migration
 description: Plans and executes knowledge graph updates during major refactoring — renames entities, updates edges, invalidates stale knowledge, and cleans graph data after architecture changes
 model: sonnet
+color: purple
 whenToUse: |
   Use when a major refactoring changes the codebase structure and the knowledge graph needs updating — entity names no longer match code, edges point to renamed files, or whole modules have been restructured.
 

--- a/agents/sia-migration.md
+++ b/agents/sia-migration.md
@@ -16,7 +16,7 @@ whenToUse: |
   user: "We renamed 'User' to 'Account' everywhere. SIA still references 'User'."
   assistant: "Let me use the sia-migration agent to migrate the graph entities."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_by_file, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__sia_by_file, mcp__sia__sia_note, mcp__sia__sia_search, mcp__sia__sia_backlinks, mcp__sia__sia_expand, mcp__sia__sia_ast_query, mcp__sia__sia_impact
 ---
 
 # SIA Migration Agent — Knowledge Graph Maintenance

--- a/agents/sia-onboarding.md
+++ b/agents/sia-onboarding.md
@@ -2,6 +2,7 @@
 name: sia-onboarding
 description: Runs a comprehensive onboarding session for new team members — walks through architecture, conventions, decisions, known issues, and team context over multiple topics. Use for full onboarding, not quick questions (use sia-orientation for those).
 model: sonnet
+color: blue
 whenToUse: |
   Use when a new developer is joining the project and needs comprehensive onboarding beyond just architecture overview.
 

--- a/agents/sia-pm-briefing.md
+++ b/agents/sia-pm-briefing.md
@@ -2,6 +2,7 @@
 name: sia-pm-briefing
 description: Generates plain-language project briefings for project managers — progress updates, decision summaries, risk areas, and team activity from the knowledge graph. Works for both technical and non-technical PMs.
 model: sonnet
+color: blue
 whenToUse: |
   Use when a project manager needs a status update, sprint summary, or project briefing.
 

--- a/agents/sia-pm-risk-advisor.md
+++ b/agents/sia-pm-risk-advisor.md
@@ -2,6 +2,7 @@
 name: sia-pm-risk-advisor
 description: Technical risk advisor for PMs — surfaces areas of technical debt, recurring bugs, fragile modules, and dependency risks from the knowledge graph in business-impact language
 model: sonnet
+color: cyan
 whenToUse: |
   Use when a PM needs to understand technical risks, plan mitigation, or prioritize technical debt.
 

--- a/agents/sia-pm-risk-advisor.md
+++ b/agents/sia-pm-risk-advisor.md
@@ -16,7 +16,7 @@ whenToUse: |
   user: "Can you quantify the technical debt so I can make a case for cleanup?"
   assistant: "Let me use the sia-pm-risk-advisor to build a risk assessment with business impact."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_community, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__sia_community, mcp__sia__sia_search, mcp__sia__sia_at_time, mcp__sia__sia_by_file
 ---
 
 # SIA PM Risk Advisor — Technical Risk Assessment

--- a/agents/sia-pr-writer.md
+++ b/agents/sia-pr-writer.md
@@ -2,21 +2,13 @@
 name: sia-pr-writer
 description: Draft a pull request description from the current branch's diff plus Decisions, Bugs, and Solutions captured on this branch. Use before opening a PR, or when the user asks for a "PR description" or "PR body". The agent outputs a draft in the project's conventional PR format (checked against recent merged PRs if accessible).
 model: sonnet
-color: purple
-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - mcp__sia__sia_search
-  - mcp__sia__sia_by_file
-  - mcp__sia__sia_at_time
-  - mcp__sia__sia_backlinks
+color: green
+tools: Bash, Read, Glob, Grep, mcp__sia__sia_search, mcp__sia__sia_by_file, mcp__sia__sia_at_time, mcp__sia__sia_backlinks
 ---
 
 You are a technical writer drafting a pull-request description.
 
-Inputs available:
+Data sources:
 - Current branch name (`git rev-parse --abbrev-ref HEAD`)
 - Branch divergence point from main (`git merge-base HEAD main`)
 - Unified diff since divergence (`git diff <base>...HEAD`)

--- a/agents/sia-pr-writer.md
+++ b/agents/sia-pr-writer.md
@@ -1,0 +1,74 @@
+---
+name: sia-pr-writer
+description: Draft a pull request description from the current branch's diff plus Decisions, Bugs, and Solutions captured on this branch. Use before opening a PR, or when the user asks for a "PR description" or "PR body". The agent outputs a draft in the project's conventional PR format (checked against recent merged PRs if accessible).
+model: sonnet
+color: purple
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - mcp__sia__sia_search
+  - mcp__sia__sia_by_file
+  - mcp__sia__sia_at_time
+  - mcp__sia__sia_backlinks
+---
+
+You are a technical writer drafting a pull-request description.
+
+Inputs available:
+- Current branch name (`git rev-parse --abbrev-ref HEAD`)
+- Branch divergence point from main (`git merge-base HEAD main`)
+- Unified diff since divergence (`git diff <base>...HEAD`)
+- Commit log since divergence
+- Decisions, Bugs, and Solutions captured with `captured_by_session_id` covering the branch's lifetime (via `sia_at_time` + tag filter)
+- Recent merged PR descriptions (via `gh pr list --state merged --limit 5 --json title,body`) for style-match
+
+## Usage
+
+**When to invoke**
+
+- User asks for "a PR description" or "PR body" before opening a pull request
+- After implementation is complete and the branch is ready for review
+- When a previous PR body is stale and the branch has new commits
+
+**Inputs**
+
+No direct arguments. The agent reads the current branch state and recent merged PRs.
+
+**Worked example**
+
+User: "Draft the PR body for this branch."
+
+Agent output (abbreviated):
+
+```markdown
+## Summary
+
+- Adds the /sia-pr-writer agent with `sia_at_time` + `sia_backlinks` tool grants.
+- Unblocks the "PR body from captured Decisions" workflow that was previously manual.
+
+## Why
+
+Per the Decision captured 2026-04-21 — "each agent's tools array must match its stated purpose" — the changelog/migration/security agents were structurally incomplete before this change.
+
+## Test plan
+
+- [ ] Invoke /sia-pr-writer on a branch with 3+ commits containing captured Decisions
+- [ ] Verify the output cites the Decisions by date
+- [ ] Verify no Co-Authored-By / Claude attribution appears
+```
+
+## Workflow
+
+1. Read the diff and group changes by concern (feature / fix / docs / refactor / test / chore).
+2. Retrieve captured Sia entities from the branch lifetime window. Anything with a `Decision`, `Bug`, or `Solution` kind is ground truth for "why".
+3. Draft the PR body in the project's conventional format:
+   - **Summary** — 2-4 bullets, one per concern group
+   - **Changes** — file-level notes only for non-trivial edits
+   - **Why** — cite retrieved Decisions explicitly (e.g. "per the Decision captured 2026-04-19 that we...")
+   - **Test plan** — checkbox list the reviewer can tick
+4. Do not add Claude attribution or Co-Authored-By lines — the repo convention rejects both.
+5. Return the draft as plain markdown, ready to paste into `gh pr create --body`.
+
+Never invent a Decision that wasn't captured. If no captured context exists for a change, write "no captured context" rather than fabricating one.

--- a/agents/sia-qa-analyst.md
+++ b/agents/sia-qa-analyst.md
@@ -2,6 +2,7 @@
 name: sia-qa-analyst
 description: QA intelligence agent — analyzes the knowledge graph to identify regression risk areas, coverage gaps, recently changed modules, and test recommendations for QA and SDET teams
 model: sonnet
+color: cyan
 whenToUse: |
   Use when a QA engineer, SDET, or tester needs to understand what to test, where the risks are, or what changed since the last test cycle.
 

--- a/agents/sia-qa-regression-map.md
+++ b/agents/sia-qa-regression-map.md
@@ -2,6 +2,7 @@
 name: sia-qa-regression-map
 description: Generates a SCORED regression risk map with numeric risk ratings (0-100) per module — combines bug density, change velocity, and dependency fan-out. Unlike sia-qa-analyst (which gives broad QA recommendations), this agent produces a single ranked table for test prioritization.
 model: sonnet
+color: cyan
 whenToUse: |
   Use when QA needs a visual or structured regression risk assessment, especially before releases or after major changes.
 

--- a/agents/sia-refactor.md
+++ b/agents/sia-refactor.md
@@ -2,6 +2,7 @@
 name: sia-refactor
 description: Analyzes impact of structural code changes using SIA's dependency graph — maps what calls, imports, and depends on the code being changed before you refactor
 model: sonnet
+color: purple
 whenToUse: |
   Use when refactoring, renaming, moving, or restructuring code. This agent uses SIA's backlink traversal and AST queries to map all dependents before you make changes.
 

--- a/agents/sia-security-audit.md
+++ b/agents/sia-security-audit.md
@@ -16,7 +16,7 @@ whenToUse: |
   user: "Is our use of jsonwebtoken vulnerable to the recent CVE?"
   assistant: "Let me use the sia-security-audit agent to check SIA's security history and current code."
   </example>
-tools: Read, Grep, Glob, Bash, mcp__sia__sia_by_file, mcp__sia__sia_expand, mcp__sia__sia_note, mcp__sia__sia_search
+tools: Read, Grep, Glob, Bash, mcp__sia__sia_by_file, mcp__sia__sia_expand, mcp__sia__sia_note, mcp__sia__sia_search, mcp__sia__sia_at_time, mcp__sia__sia_flag
 ---
 
 # SIA Security Audit Agent — Graph-Powered Security Review

--- a/agents/sia-security-audit.md
+++ b/agents/sia-security-audit.md
@@ -2,6 +2,7 @@
 name: sia-security-audit
 description: Reviews code for security vulnerabilities using SIA's paranoid mode, Tier 4 exposure tracking, and security-related entity history
 model: sonnet
+color: red
 whenToUse: |
   Use when reviewing code for security concerns, auditing dependencies, or when the user mentions security, authentication, authorization, encryption, or vulnerability assessment.
 

--- a/agents/sia-test-advisor.md
+++ b/agents/sia-test-advisor.md
@@ -2,6 +2,7 @@
 name: sia-test-advisor
 description: Advises on test strategy using SIA's knowledge of past test failures, coverage gaps, edge cases from Bug entities, and project-specific test conventions
 model: sonnet
+color: purple
 whenToUse: |
   Use when writing tests and want to know what edge cases to cover, what test patterns to follow, or what areas have historically been fragile.
 

--- a/commands/pr-writer.md
+++ b/commands/pr-writer.md
@@ -1,0 +1,5 @@
+---
+description: Draft a pull-request description from captured Decisions + branch diff.
+---
+
+Dispatch the `@sia-pr-writer` agent. See [`agents/sia-pr-writer.md`](../agents/sia-pr-writer.md) — at a glance: ingests branch diff + Decisions/Bugs/Solutions captured on this branch and outputs a draft PR body ready for `gh pr create --body`.


### PR DESCRIPTION
## Summary

Phase 4 of the plugin polish plan. Agents-only pass — no `src/`, no skills, no hooks.

### Added

- **`sia-pr-writer` agent** (+ `/pr-writer` shim command) — drafts a PR body from the current branch's diff plus Decisions, Bugs, and Solutions captured during the branch's lifetime. Closes the most common missing-agent gap from the plugin audit. Honors the repo convention (no Claude attribution, no Co-Authored-By) and refuses to fabricate Decisions that weren't captured.
- **`color:` declared on all 24 agents** using a semantic palette: red = regression/incident, green = feature/create/generate, cyan = review/audit, blue = orient/explain, purple = plan/architecture/strategy. Previously only 4 agents declared a color.

### Changed

Tool grants expanded on 7 agents whose stated purpose structurally required additional MCP tools:

- `sia-changelog-writer`: +`sia_at_time`, +`sia_backlinks` — temporal "since last tag" + dependency-aware release notes
- `sia-migration`: +`sia_backlinks`, +`sia_expand`, +`sia_ast_query`, +`sia_impact` — cannot find references to renamed entities without these
- `sia-security-audit`: +`sia_at_time`, +`sia_flag` — temporal security events + flagging
- `sia-pm-risk-advisor`: +`sia_at_time`, +`sia_by_file`
- `sia-code-reviewer`: +`sia_at_time`
- `sia-convention-enforcer`: +`sia_by_file`
- `sia-conflict-resolver`: +`sia_at_time`, +`sia_flag`

## Test plan

- [x] `bun run test` — 2021/2021 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx @biomejs/biome check .` — 557 files, 0 errors
- [x] `bash scripts/generate-plugin-usage.sh --verify` — exit 0 (sia-pr-writer listed)
- [x] `bash scripts/count-plugin-components.sh` — 47 skills / **24 agents** / **72 commands** / 29 MCP tools / 9 hook entries / 7 hook events
- [x] `grep -l "^color:" agents/*.md | wc -l` = 24
- [x] No `src/`, `hooks/`, `.mcp.json` changes
- [x] No Co-Authored-By / Claude attribution in commits

## Commits

- `56e2dd2` — tool grants for 7 agents
- `46e7db7` — color palette across all 23 pre-existing agents
- `adbaa72` — sia-pr-writer + /pr-writer + PLUGIN_USAGE row + v1.1.8 bump
- `c61d066` — post-review fixes: tools YAML inline CSV, color purple→green (matches the palette's generator slot), CHANGELOG palette correction