### PR TITLE
feat(plugin): runtime + discoverability (phase 5); v1.1.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.8"
+		"version": "1.1.9"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.8",
+			"version": "1.1.9",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.1.8"
+	"version": "1.1.9"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.1.9] - 2026-04-21
+
+### Added
+- SessionStart emits `[Sia] No graph detected for this project. Run
+  /sia-setup to bootstrap` when the graph has zero active entities.
+  Closes the silent first-run loop — previously a user with a fresh
+  install saw no Sia output at all. Gated on the `graph_nodes` table
+  existing; no error if a brand-new session predates the schema.
+- `ensure-runtime.sh` now logs every invocation to
+  `${CLAUDE_PLUGIN_DATA}/logs/ensure-runtime.log` and prints a
+  one-line notice to stderr before auto-installing bun.
+- Stamp-file-gated invocation of `postinstall.sh` from
+  `ensure-runtime.sh`. The `.git` strip and native tree-sitter
+  rebuild previously never ran on a fresh install; they now run
+  exactly once, logging to
+  `${CLAUDE_PLUGIN_DATA}/logs/postinstall.log`.
+- `/sia-setup` ends by calling `sia_stats` and suggesting three
+  follow-up commands so the user sees the bootstrap worked and has
+  an obvious next action.
+
+### Changed
+- `scripts/postinstall.sh` no longer swallows build stderr with
+  `2>/dev/null`. Failures are now visible in the new postinstall
+  log.
+- `hooks/hooks.json` — the `PostToolUse` `Write|Edit|Read` matcher
+  now carries a `_comment` documenting why `Read` is intentionally
+  included (the handler queries the graph for entities associated
+  with the read file and returns them as context — see
+  `handlers/post-tool-use.ts:379`).
+
 ## [1.1.8] - 2026-04-21
 
 ### Added

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -25,6 +25,7 @@
 		],
 		"PostToolUse": [
 			{
+				"_comment": "Read is intentionally included — handlers/post-tool-use.ts#handleRead queries the graph for entities associated with the read file and returns them as context. Dropping Read would remove the 'touch for importance' signal and file-read context hints. See handlers/post-tool-use.ts:379.",
 				"matcher": "Write|Edit|Read",
 				"hooks": [
 					{

--- a/scripts/ensure-runtime.sh
+++ b/scripts/ensure-runtime.sh
@@ -6,13 +6,22 @@ set -euo pipefail
 
 PLUGIN_ROOT="${1:-.}"
 
+# Audit log: every invocation appends a line so diagnostics have a trail.
+SIA_LOG_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.sia}/logs"
+mkdir -p "$SIA_LOG_DIR" 2>/dev/null || true
+{
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ensure-runtime invoked (plugin_root=$PLUGIN_ROOT pid=$$)"
+} >> "$SIA_LOG_DIR/ensure-runtime.log" 2>/dev/null || true
+
 # 1. Check for bun
 if ! command -v bun &>/dev/null; then
     # Try common install locations
     if [ -f "$HOME/.bun/bin/bun" ]; then
         export PATH="$HOME/.bun/bin:$PATH"
     else
-        # Auto-install bun
+        # Auto-install bun. Surface a one-line notice so the user
+        # knows why the first session feels slow.
+        echo "sia: installing bun to \$HOME/.bun/ (one-time, ~20s)" >&2
         echo "[sia] bun not found — installing..." >&2
         curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
         export PATH="$HOME/.bun/bin:$PATH"
@@ -29,4 +38,13 @@ if [ ! -d "$PLUGIN_ROOT/node_modules" ]; then
     echo "[sia] installing dependencies..." >&2
     (cd "$PLUGIN_ROOT" && bun install --production 2>/dev/null)
     echo "[sia] dependencies installed" >&2
+
+    # Run postinstall once per fresh install. Stamp file prevents re-runs.
+    POSTINSTALL_STAMP="${CLAUDE_PLUGIN_DATA:-$HOME/.sia}/.postinstalled"
+    if [ ! -f "$POSTINSTALL_STAMP" ]; then
+        mkdir -p "$(dirname "$POSTINSTALL_STAMP")"
+        bash "${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/scripts/postinstall.sh" \
+            >> "${CLAUDE_PLUGIN_DATA:-$HOME/.sia}/logs/postinstall.log" 2>&1 || true
+        touch "$POSTINSTALL_STAMP"
+    fi
 fi

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -21,7 +21,7 @@ fi
 
 echo "sia: rebuilding tree-sitter native binding with C++20..."
 cd "$TS_DIR"
-if CXXFLAGS="-std=c++20" npx node-gyp rebuild 2>/dev/null; then
+if CXXFLAGS="-std=c++20" npx node-gyp rebuild; then
     echo "sia: native tree-sitter built successfully"
 else
     echo "sia: native tree-sitter build failed — WASM fallback will be used"

--- a/skills/sia-setup/SKILL.md
+++ b/skills/sia-setup/SKILL.md
@@ -62,7 +62,11 @@ Or invoke `/sia-tour` for an interactive walkthrough.
 
 ### Step 5: Summary
 
-Present what SIA learned:
+After setup completes, call the `sia_stats` MCP tool and display the graph
+state so the user sees the bootstrap worked. Then suggest three follow-up
+commands so there is an obvious next action.
+
+Present what SIA learned, filling in real numbers from `sia_stats`:
 > **SIA is ready!**
 > - 342 code entities indexed across 142 files
 > - 45 documentation chunks from 8 docs
@@ -70,8 +74,12 @@ Present what SIA learned:
 > - 3 external references (Notion, Jira, GitHub)
 >
 > Try these next:
+> - `/sia-search <topic>` — try a search to see if prior context was captured
+> - `/sia-visualize-live` — open the graph in your browser
+> - `/sia-learn --incremental` — update the graph as you continue working
+>
+> Other useful commands:
 > - Ask me any question — SIA tools activate automatically
-> - `/sia-search` — search the knowledge graph
 > - `/sia-status` — check graph health
 > - `/sia-team` — set up team sync
 

--- a/src/hooks/plugin-session-start.ts
+++ b/src/hooks/plugin-session-start.ts
@@ -13,6 +13,7 @@ import { incrementalReindex, readStoredHead } from "@/capture/incremental-reinde
 import { openGraphDb } from "@/graph/semantic-db";
 import { buildSessionContext, formatSessionContext } from "@/hooks/handlers/session-start";
 import { parsePluginHookEvent, readStdin } from "@/hooks/plugin-common";
+import { getEmptyGraphHint } from "@/hooks/session-start-hints";
 import type { HookEvent } from "@/hooks/types";
 import { runSessionStart as runNousSessionStart } from "@/nous/self-monitor";
 import { DEFAULT_NOUS_CONFIG } from "@/nous/types";
@@ -142,6 +143,9 @@ async function main() {
 
 			// First-run UX: hint to download T0 models if missing.
 			formatted += getModelInstallHint();
+
+			// First-run UX: hint to run /sia-setup when the graph is empty.
+			formatted += await getEmptyGraphHint(db);
 
 			// Nous: run self-monitor and inject drift warning if needed.
 			// Must not break SessionStart — any failure is logged and ignored.

--- a/src/hooks/session-start-hints.ts
+++ b/src/hooks/session-start-hints.ts
@@ -1,0 +1,36 @@
+// SessionStart first-run hints.
+//
+// Small pure helpers that decide whether to emit a one-line nudge
+// (empty graph, missing model, etc.) when the user opens a session.
+// Kept in a separate module so they are importable by tests without
+// triggering the hook's main() side-effects.
+
+export interface HintDb {
+	execute: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>;
+}
+
+/**
+ * First-run hint: if the graph has zero active entities, nudge the user to
+ * run /sia-setup. Returns an empty string silently if the `graph_nodes`
+ * table doesn't exist yet (brand-new session predating schema) or any
+ * error occurs — this hint must never break SessionStart.
+ */
+export async function getEmptyGraphHint(db: HintDb): Promise<string> {
+	try {
+		const tableCheck = await db.execute(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name='graph_nodes'",
+		);
+		if (tableCheck.rows.length === 0) return "";
+		const countResult = await db.execute(
+			"SELECT COUNT(*) AS c FROM graph_nodes WHERE archived_at IS NULL",
+		);
+		const row = countResult.rows[0] as { c?: number } | undefined;
+		const count = Number(row?.c ?? 0);
+		if (count === 0) {
+			return "\n[Sia] No graph detected for this project. Run /sia-setup to bootstrap (~2 min). See README for the 5-step wizard.\n";
+		}
+		return "";
+	} catch {
+		return "";
+	}
+}

--- a/src/hooks/session-start-hints.ts
+++ b/src/hooks/session-start-hints.ts
@@ -9,11 +9,19 @@ export interface HintDb {
 	execute: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>;
 }
 
+export const EMPTY_GRAPH_HINT =
+	"\n[Sia] No graph detected for this project. Run /sia-setup to bootstrap (~2 min). See README for the 5-step wizard.\n";
+
 /**
  * First-run hint: if the graph has zero active entities, nudge the user to
- * run /sia-setup. Returns an empty string silently if the `graph_nodes`
- * table doesn't exist yet (brand-new session predating schema) or any
- * error occurs — this hint must never break SessionStart.
+ * run /sia-setup. Returns an empty string when:
+ *  - the `graph_nodes` table doesn't exist yet (brand-new session, no migrations)
+ *  - the table exists but has at least one active entity
+ *  - an unexpected error occurred (logged to stderr; hint must never break SessionStart)
+ *
+ * "Active" uses the canonical Sia filter: `t_valid_until IS NULL AND archived_at IS NULL`
+ * — the same predicate `src/graph/entities.ts` uses so a bi-temporally invalidated
+ * graph is still treated as empty here.
  */
 export async function getEmptyGraphHint(db: HintDb): Promise<string> {
 	try {
@@ -22,15 +30,15 @@ export async function getEmptyGraphHint(db: HintDb): Promise<string> {
 		);
 		if (tableCheck.rows.length === 0) return "";
 		const countResult = await db.execute(
-			"SELECT COUNT(*) AS c FROM graph_nodes WHERE archived_at IS NULL",
+			"SELECT COUNT(*) AS c FROM graph_nodes WHERE t_valid_until IS NULL AND archived_at IS NULL",
 		);
 		const row = countResult.rows[0] as { c?: number } | undefined;
 		const count = Number(row?.c ?? 0);
-		if (count === 0) {
-			return "\n[Sia] No graph detected for this project. Run /sia-setup to bootstrap (~2 min). See README for the 5-step wizard.\n";
-		}
-		return "";
-	} catch {
+		return count === 0 ? EMPTY_GRAPH_HINT : "";
+	} catch (err) {
+		process.stderr.write(
+			`[sia] empty-graph hint failed (non-fatal): ${err instanceof Error ? err.message : String(err)}\n`,
+		);
 		return "";
 	}
 }

--- a/tests/unit/hooks/plugin-session-start.test.ts
+++ b/tests/unit/hooks/plugin-session-start.test.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from "node:crypto";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SiaDb } from "@/graph/db-interface";
+import { insertEntity } from "@/graph/entities";
+import { openGraphDb } from "@/graph/semantic-db";
+import { getEmptyGraphHint, type HintDb } from "@/hooks/session-start-hints";
+
+function makeTmp() {
+	return join(tmpdir(), `sia-session-start-${randomUUID()}`);
+}
+
+describe("getEmptyGraphHint", () => {
+	let db: SiaDb | undefined;
+	let tmpDir = "";
+
+	afterEach(async () => {
+		await db?.close();
+		db = undefined;
+		if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+		tmpDir = "";
+	});
+
+	it("emits the /sia-setup hint when the graph has zero active entities", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-empty", tmpDir);
+
+		const hint = await getEmptyGraphHint(db);
+		expect(hint).toContain("No graph detected");
+		expect(hint).toContain("/sia-setup");
+	});
+
+	it("does NOT emit the hint when the graph contains at least one active entity", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-populated", tmpDir);
+
+		// Seed one active node so the graph is non-empty. insertEntity
+		// sets archived_at=null by default, which is what the hint filters on.
+		await insertEntity(db, {
+			type: "Concept",
+			name: "Test Entity",
+			content: "seed row so the graph is non-empty",
+			summary: "seed",
+		});
+
+		const hint = await getEmptyGraphHint(db);
+		expect(hint).toBe("");
+	});
+
+	it("returns an empty string (no throw, no hint) when graph_nodes table is missing", async () => {
+		// Fake a db handle that reports the table doesn't exist.
+		const fakeDb: HintDb = {
+			execute: async (sql: string) => {
+				if (sql.includes("sqlite_master")) {
+					return { rows: [] };
+				}
+				throw new Error("graph_nodes should not be queried when the table is missing");
+			},
+		};
+
+		let hint: string | undefined;
+		await expect(
+			(async () => {
+				hint = await getEmptyGraphHint(fakeDb);
+			})(),
+		).resolves.toBeUndefined();
+		expect(hint).toBe("");
+	});
+});

--- a/tests/unit/hooks/plugin-session-start.test.ts
+++ b/tests/unit/hooks/plugin-session-start.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { SiaDb } from "@/graph/db-interface";
 import { insertEntity } from "@/graph/entities";
 import { openGraphDb } from "@/graph/semantic-db";
-import { getEmptyGraphHint, type HintDb } from "@/hooks/session-start-hints";
+import { EMPTY_GRAPH_HINT, getEmptyGraphHint, type HintDb } from "@/hooks/session-start-hints";
 
 function makeTmp() {
 	return join(tmpdir(), `sia-session-start-${randomUUID()}`);
@@ -28,8 +28,27 @@ describe("getEmptyGraphHint", () => {
 		db = openGraphDb("test-empty", tmpDir);
 
 		const hint = await getEmptyGraphHint(db);
-		expect(hint).toContain("No graph detected");
-		expect(hint).toContain("/sia-setup");
+		expect(hint).toBe(EMPTY_GRAPH_HINT);
+	});
+
+	it("does NOT emit the hint when every entity is bi-temporally invalidated", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-invalidated", tmpDir);
+
+		// Seed via the canonical path, then bi-temporally invalidate. The active
+		// filter requires BOTH t_valid_until IS NULL AND archived_at IS NULL, so a
+		// row with t_valid_until set should still trigger the empty-graph hint.
+		await insertEntity(db, {
+			type: "Concept",
+			name: "Retired",
+			content: "to be invalidated",
+			summary: "r",
+		});
+		const now = Math.floor(Date.now() / 1000);
+		await db.execute("UPDATE graph_nodes SET t_valid_until = ?", [now]);
+
+		const hint = await getEmptyGraphHint(db);
+		expect(hint).toBe(EMPTY_GRAPH_HINT);
 	});
 
 	it("does NOT emit the hint when the graph contains at least one active entity", async () => {


### PR DESCRIPTION
## Summary

Phase 5 of the plugin polish plan. First phase that touches production `src/` code — adds the empty-graph first-run hint, wires `postinstall.sh` to run via `ensure-runtime.sh`, and tightens `/sia-setup` with a stats summary and three follow-up commands.

### Added

- **Empty-graph SessionStart hint.** When a user opens a Claude Code session in a project whose Sia graph has zero active entities, SessionStart now emits:
  > `[Sia] No graph detected for this project. Run /sia-setup to bootstrap (~2 min). See README for the 5-step wizard.`
  
  Closes the silent first-run loop — previously a fresh install showed no Sia output at all and the user had no obvious next action. Implementation uses the canonical active-entity filter (`t_valid_until IS NULL AND archived_at IS NULL`), matching `src/graph/entities.ts`, so a bi-temporally invalidated graph is also treated as empty. Gated on the `graph_nodes` table existing (brand-new sessions predating migrations silently skip). Errors are logged to stderr with the `[sia] … failed (non-fatal)` prefix used by the rest of the file — the hint never throws.
- **`scripts/ensure-runtime.sh` logging + transparency.** Every invocation appends a line to `${CLAUDE_PLUGIN_DATA:-$HOME/.sia}/logs/ensure-runtime.log`. A one-line stderr notice is printed before auto-installing bun so users aren't surprised by the `curl | bash`.
- **`postinstall.sh` now actually runs.** It was dead code — Claude Code plugin lifecycle has no post-install hook. Wired into `ensure-runtime.sh` with a stamp file (`${CLAUDE_PLUGIN_DATA}/.postinstalled`) that gates invocation so it runs exactly once per fresh install. stderr lands in `${CLAUDE_PLUGIN_DATA}/logs/postinstall.log`. `|| true` so a postinstall failure never breaks the session.
- **`/sia-setup` ends with a stats summary + three suggested next commands** so the user sees the bootstrap worked and has an obvious next move.

### Changed

- `scripts/postinstall.sh` no longer swallows node-gyp stderr with `2>/dev/null`. Failures are now visible in the new postinstall log.
- `hooks/hooks.json` PostToolUse matcher keeps `Read` — audit confirmed `src/hooks/handlers/post-tool-use.ts#handleRead` uses Read events for context-injection ("touch for importance"). Added a `_comment` pointing at the handler line so a future reader understands why.

## Test plan

- [x] `bun run test` — **2025/2025 pass** (up 4 from baseline: 3 empty/populated/missing-table cases + 1 bi-temporally-invalidated case)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx @biomejs/biome check .` — 559 files, 0 errors
- [x] `bash scripts/count-plugin-components.sh` — 47 / 24 / 72 / 29 / 9 / 7 (unchanged)
- [x] Empty graph → hint emitted; populated graph → no hint; invalidated graph → hint emitted; missing table → no throw no hint
- [x] No unrelated `src/` changes (only `src/hooks/plugin-session-start.ts` + new helper `src/hooks/session-start-hints.ts`)
- [x] No Co-Authored-By / Claude attribution in commits

## Commits

- `3e32d0a` — empty-graph hint on SessionStart + tests
- `bf27e7d` — wire postinstall + ensure-runtime transparency
- `071301e` — /sia-setup polish + v1.1.9 + CHANGELOG
- `6bbca25` — post-review fixes: canonical SQL filter, stderr logging on errors, exported hint constant, additional bi-temporal invalidation test