### PR TITLE
feat(plugin): nice-to-haves (phase 7); v1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.1.10"
+		"version": "1.2.0"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.1.10",
+			"version": "1.2.0",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.1.10"
+	"version": "1.2.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.1.10",
+	"version": "1.2.0",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-21
+
+### Added
+- **Two new agents** bringing the library to 26 agents:
+  - `sia-search-debugger` (blue, diagnostic) — when `sia_search`
+    returns nothing or off-target, diagnoses whether the graph is
+    empty, vocabulary is off, or knowledge was never captured;
+    proposes reformulated queries. Matching `/search-debugger` shim.
+  - `sia-doc-writer` (green, generator) — generates ADRs, README
+    architecture sections, and module docs directly from captured
+    Decisions, Conventions, and community summaries. Cites every
+    claim; never fabricates rationale. Matching `/doc-writer` shim.
+- `commands/README.md`, `agents/README.md`, `skills/README.md`, and
+  `hooks/README.md` — contributor-facing authoring guides covering
+  file shape, frontmatter, the Phase 4 colour palette, the
+  trigger-style description guide, and the hook event matrix. End-user
+  guidance continues to live in `PLUGIN_USAGE.md`.
+- `argument-hint:` on `commands/learn.md` — the only command whose
+  body referenced `$ARGUMENTS` without declaring the hint. Caught
+  during the Phase 7.6 frontmatter sweep.
+
+### Changed
+- **PLUGIN_README.md slimmed from 267 → 98 lines** as a
+  quick-reference card. Prior versions duplicated ~40% of README.md
+  prose and drifted independently (the v1.1.5 and v1.1.10 count-fix
+  patches are the motivating examples). The new PLUGIN_README links
+  to README / CLAUDE / PLUGIN_USAGE / CONTRIBUTING / SECURITY for
+  authoritative content and retains only the 29-row MCP tool table,
+  install command, and hook event pointer.
+- `scripts/count-plugin-components.sh`,
+  `scripts/validate-plugin.sh`, and
+  `scripts/generate-plugin-usage.sh` now exclude `README.md` from
+  agent / command / skill iteration loops so the new component-dir
+  READMEs do not inflate counts.
+
+### Skipped / deferred
+- **Command-palette pruning (7.3)** — the 73 → ~40 goal risks
+  breaking user muscle memory because every skill shim is a shorter
+  alias (`/search` ↔ `/sia-search`) with no clear duplicate-vs-alias
+  cut line. Deferred to Phase 8 where a principled rule can be
+  drafted.
+- **Inline `mcpServers` in `plugin.json` (7.5)** — the repo's
+  `.mcp.json` at root is auto-discovered by Claude Code and verified
+  working; inlining is a newer idiom that was not verified in this
+  phase. Leaving `.mcp.json` in place; deferred to a dedicated
+  manifest-migration patch.
+
 ## [1.1.10] - 2026-04-21
 
 ### Added

--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -162,7 +162,7 @@ See [PLUGIN_USAGE.md](PLUGIN_USAGE.md) for per-skill, per-agent, per-command usa
 | `/sia-pm-decision-log` | Chronological decision log with rationale |
 | `/sia-pm-risk-dashboard` | Technical risk dashboard scored by impact |
 
-### Subagents (24 agents)
+### Subagents (26 agents)
 
 | Agent | Purpose | Category |
 |---|---|---|
@@ -171,6 +171,8 @@ See [PLUGIN_USAGE.md](PLUGIN_USAGE.md) for per-skill, per-agent, per-command usa
 | `sia-onboarding` | Comprehensive multi-topic onboarding session | Onboarding |
 | `sia-decision-reviewer` | Decision archaeology — past choices and rejected alternatives | Planning |
 | `sia-explain` | Explains SIA's tools, graph structure, and workflows | Meta |
+| `sia-search-debugger` | Diagnoses empty / off-target `sia_search` results | Diagnostic |
+| `sia-doc-writer` | Generates ADRs / README sections from Decisions + Conventions | Documentation |
 | **During Coding** | | |
 | `sia-feature` | Feature dev with convention awareness and dependency context | Development |
 | `sia-refactor` | Impact analysis via dependency graph before structural changes | Development |

--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -1,262 +1,91 @@
-# SIA — Claude Code Plugin
+# SIA — Claude Code Plugin (Quick Reference)
 
 Persistent graph memory for AI coding agents. SIA gives Claude Code cross-session memory via a bi-temporal knowledge graph.
 
-## Installation
+This is a **quick-reference card**. For product overview, architecture, and full usage guides, see:
+
+- [README.md](README.md) — product overview, differentiators, quick start
+- [CLAUDE.md](CLAUDE.md) — agent behavioural contract loaded every session
+- [PLUGIN_USAGE.md](PLUGIN_USAGE.md) — per-skill, per-agent, per-command usage guides
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to contribute, tests, pre-commit
+- [SECURITY.md](SECURITY.md) — vulnerability reporting
+
+## Install
 
 ```bash
-# From marketplace (installs at user scope — available in all projects)
+# Marketplace (installs at user scope — available in all projects)
+/plugin marketplace add rkarim08/sia
 /plugin install sia@sia-plugins
 ```
 
-Or for local development (project-scoped by design):
+For local development (project-scoped): `claude --plugin-dir /path/to/sia`.
 
-```bash
-claude --plugin-dir /path/to/sia
-```
-
-> **Note:** Local development mode (`--plugin-dir`) is project-scoped.
-> For cross-project usage, install from the marketplace.
-
-### Full component usage
-
-See [PLUGIN_USAGE.md](PLUGIN_USAGE.md) for per-skill, per-agent, per-command usage guides with invocation triggers and worked examples.
-
-## Features
-
-### MCP Tools (always available)
-
-#### Search & Retrieval
+## MCP Tools (29)
 
 | Tool | Description |
 |---|---|
-| `sia_search` | Semantic search across the knowledge graph |
-| `sia_by_file` | Look up knowledge for a specific file |
-| `sia_expand` | Explore entity neighborhoods (1-3 hops) |
-| `sia_community` | Get community-level summaries |
-| `sia_at_time` | Query the graph at a historical point |
-| `sia_backlinks` | Find incoming edges to a node |
-
-#### Knowledge Capture
-
-| Tool | Description |
-|---|---|
-| `sia_note` | Record a Decision, Convention, Bug, Solution, or Concept |
+| `sia_models` | Check transformer model tier status, installed models, and attention head training phase |
+| `sia_search` | Semantic search across the Sia knowledge graph |
+| `sia_by_file` | Retrieve knowledge graph nodes associated with a file |
+| `sia_expand` | Expand an entity's neighbourhood in the knowledge graph |
+| `sia_community` | Retrieve community-level summaries from the knowledge graph |
+| `sia_at_time` | Query the knowledge graph at a point in time |
 | `sia_flag` | Flag current session for human review (writes to session_flags only) |
-| `sia_index` | Index markdown/text content by chunking and scanning for entity references |
-| `sia_fetch_and_index` | Fetch a URL, convert to markdown, and index |
-
-#### Sandbox Execution
-
-| Tool | Description |
-|---|---|
+| `sia_backlinks` | Find all incoming edges (backlinks) to a knowledge graph node |
+| `sia_note` | Create a developer-authored knowledge entry in the graph |
 | `sia_execute` | Execute code in an isolated sandbox |
 | `sia_execute_file` | Execute an existing file in a sandbox subprocess |
+| `sia_index` | Index markdown/text content by chunking and scanning for entity references |
 | `sia_batch_execute` | Execute multiple operations in one call with precedes edges |
-
-#### AST & Code Analysis
-
-| Tool | Description |
-|---|---|
-| `sia_ast_query` | Run tree-sitter queries against source files for structural code analysis |
-
-#### Branch Snapshots
-
-| Tool | Description |
-|---|---|
-| `sia_snapshot_list` | List branch snapshots with timestamps and entity counts |
-| `sia_snapshot_restore` | Restore graph state from a branch snapshot |
-| `sia_snapshot_prune` | Remove snapshots for deleted or merged branches |
-
-#### Diagnostics & Maintenance
-
-| Tool | Description |
-|---|---|
-| `sia_stats` | Graph metrics — node/edge counts by type, optional session stats |
-| `sia_doctor` | Run diagnostic checks on the installation |
-| `sia_upgrade` | Self-update SIA to the latest version |
+| `sia_fetch_and_index` | Fetch a URL, convert to markdown, and index |
+| `sia_stats` | Return graph metrics: node/edge counts by type, optional session stats |
+| `sia_doctor` | Run diagnostic checks on the Sia installation |
+| `sia_upgrade` | Self-update Sia to the latest version |
 | `sia_sync_status` | Check team sync configuration and connection status |
-
-### Skills (47 slash commands)
-
-#### Core
-
-| Skill | Description |
-|---|---|
-| `/sia-install` | Initialize SIA in current project |
-| `/sia-search` | Guided search with examples |
-| `/sia-stats` | Graph statistics |
-| `/sia-status` | Knowledge graph health dashboard |
-| `/sia-reindex` | Re-index repository code |
-| `/sia-learn` | Build or refresh the complete knowledge graph |
-| `/sia-playbooks` | Load task-specific playbooks (regression, feature, review, orientation) |
-
-#### Knowledge Management
-
-| Skill | Description |
-|---|---|
-| `/sia-capture` | Guided knowledge capture — decisions, conventions, bugs, solutions |
-| `/sia-execute` | Run code in sandbox with knowledge capture |
-| `/sia-index` | Index external content (text, URLs) |
-| `/sia-workspace` | Manage cross-repo workspaces |
-| `/sia-export-import` | Export/import graphs as portable JSON |
-| `/sia-export-knowledge` | Export graph as human-readable KNOWLEDGE.md |
-| `/sia-history` | Explore temporal knowledge evolution |
-| `/sia-impact` | Analyze impact of planned code changes |
-| `/sia-compare` | Compare graph state between two time points |
-
-#### Development Workflow
-
-| Skill | Description |
-|---|---|
-| `/sia-brainstorm` | Brainstorm features using graph context |
-| `/sia-plan` | Write implementation plans with graph topology |
-| `/sia-execute-plan` | Execute plans with staleness detection and convention checks |
-| `/sia-dispatch` | Dispatch parallel agents with community-based independence verification |
-| `/sia-test` | TDD guided by known edge cases and test conventions |
-| `/sia-verify` | Verify work completeness against area-specific requirements |
-| `/sia-debug-workflow` | Systematic debugging with temporal root-cause tracing |
-| `/sia-finish` | Finish branches — semantic PR summaries from graph entities |
-| `/sia-review-respond` | Respond to code review feedback with graph-backed evidence |
-
-#### Maintenance
-
-| Skill | Description |
-|---|---|
-| `/sia-doctor` | System health diagnostics |
-| `/sia-digest` | Daily knowledge summary |
-| `/sia-visualize` | Generate HTML graph visualization |
-| `/sia-visualize-live` | Launch interactive browser-based graph visualizer |
-| `/sia-freshness` | Graph freshness report |
-| `/sia-conflicts` | List and resolve knowledge conflicts |
-| `/sia-prune` | Remove archived entities |
-| `/sia-upgrade` | Self-update SIA |
-
-#### Onboarding
-
-| Skill | Description |
-|---|---|
-| `/sia-setup` | Guided first-time setup with checklist |
-| `/sia-tour` | Interactive guided tour of the knowledge graph |
-
-#### Team Sync
-
-| Skill | Description |
-|---|---|
-| `/sia-team` | Join, leave, or check team sync status |
-| `/sia-sync` | Manual push/pull to/from team server |
-
-#### QA & Testing Intelligence
-
-| Skill | Description |
-|---|---|
-| `/sia-qa-report` | QA-focused report — risky areas, test priorities |
-| `/sia-qa-coverage` | Test coverage gap analysis from the knowledge graph |
-| `/sia-qa-flaky` | Track flaky test patterns and recurring failures |
-
-#### Project Management Intelligence
-
-| Skill | Description |
-|---|---|
-| `/sia-pm-sprint-summary` | Sprint summary in plain language for PMs |
-| `/sia-pm-decision-log` | Chronological decision log with rationale |
-| `/sia-pm-risk-dashboard` | Technical risk dashboard scored by impact |
-
-### Subagents (26 agents)
-
-| Agent | Purpose | Category |
-|---|---|---|
-| **Before Coding** | | |
-| `sia-orientation` | Quick architecture Q&A — single focused answers | Onboarding |
-| `sia-onboarding` | Comprehensive multi-topic onboarding session | Onboarding |
-| `sia-decision-reviewer` | Decision archaeology — past choices and rejected alternatives | Planning |
-| `sia-explain` | Explains SIA's tools, graph structure, and workflows | Meta |
-| `sia-search-debugger` | Diagnoses empty / off-target `sia_search` results | Diagnostic |
-| `sia-doc-writer` | Generates ADRs / README sections from Decisions + Conventions | Documentation |
-| **During Coding** | | |
-| `sia-feature` | Feature dev with convention awareness and dependency context | Development |
-| `sia-refactor` | Impact analysis via dependency graph before structural changes | Development |
-| `sia-convention-enforcer` | Convention compliance check against known standards | Quality |
-| `sia-test-advisor` | Test strategy from past failures and known edge cases | Testing |
-| `sia-dependency-tracker` | Cross-repo dependency monitoring and API contract tracking | Architecture |
-| **During Debugging** | | |
-| `sia-debug-specialist` | Active bug investigation with temporal root-cause tracing | Debugging |
-| `sia-regression` | Proactive regression risk analysis for code changes | Prevention |
-| **During Review** | | |
-| `sia-code-reviewer` | Code review with historical context and convention enforcement | Review |
-| `sia-security-audit` | Security review with paranoid mode and Tier 4 exposure tracking | Security |
-| `sia-conflict-resolver` | Resolve contradicting knowledge entities | Quality |
-| **After Coding** | | |
-| `sia-knowledge-capture` | Systematic session capture — decisions, conventions, bugs, solutions | Capture |
-| `sia-changelog-writer` | Graph-powered changelogs and release notes | Documentation |
-| `sia-migration` | Graph maintenance during major refactors | Maintenance |
-| **QA & Testing** | | |
-| `sia-qa-analyst` | QA intelligence — regression risks, coverage gaps, test recommendations | QA |
-| `sia-qa-regression-map` | Scored regression risk map (0-100) per module for test prioritization | QA |
-| **Project Management** | | |
-| `sia-pm-briefing` | Plain-language project briefings for PMs | PM |
-| `sia-pm-risk-advisor` | Technical risk advisor — debt, fragile modules, dependency risks | PM |
-| **Tech Lead** | | |
-| `sia-lead-architecture-advisor` | Architecture drift detection against captured decisions | Leadership |
-| `sia-lead-team-health` | Team knowledge health — coverage gaps, bus-factor risks | Leadership |
-
-All subagents primarily retrieve from the knowledge graph and can run simultaneously.
-The feature agent may flag decisions via `sia_flag` when flagging is enabled.
-The knowledge-capture agent is designed for end-of-session use rather than parallel execution.
-Invoke via `@sia-code-reviewer`, `@sia-orientation`, etc.
-
-### Automatic Hooks
-
-| Hook | Trigger | Purpose |
-|---|---|---|
-| **PostToolUse** | Write/Edit | Captures knowledge from file changes |
-| **PostToolUse** | Bash | Detects branch switches and saves/restores graph snapshots |
-| **Stop** | Session stop | Detects uncaptured knowledge patterns |
-| **SessionStart** | Session begin | Injects recent decisions/conventions as context |
-| **PreCompact** | Before compaction | Scans transcript tail for unextracted knowledge before context compaction |
-| **PostCompact** | After compaction | Logs compaction coverage for observability |
-| **SessionEnd** | Session exit | Records session statistics and entity counts |
-| **UserPromptSubmit** | User prompt | Captures user prompts and detects correction/preference patterns |
-
-## Nous Cognitive Layer
-
-Nous is Sia's cognitive layer — drift monitoring, self-reflection, and anti-sycophancy guardrails. Four always-active hooks (SessionStart drift, PreToolUse significance, PostToolUse discomfort + surprise, Stop episode) run alongside Sia's capture path. Five MCP tools are available for explicit invocation:
-
-| Tool | Purpose |
-|---|---|
+| `sia_ast_query` | Parse a file with tree-sitter and extract symbols, imports, or call relationships |
+| `sia_impact` | Analyze the blast radius of a change to a knowledge graph entity |
+| `sia_detect_changes` | Detect changed files from git diff and map to knowledge graph entities |
+| `sia_snapshot_list` | List all branch-keyed graph snapshots |
+| `sia_snapshot_restore` | Restore the knowledge graph from a branch snapshot |
+| `sia_snapshot_prune` | Remove branch snapshots for specified branches |
 | `nous_state` | Read drift score, active Preferences, recent signals |
-| `nous_reflect` | Self-monitor pass — per-preference alignment + recommended action |
+| `nous_reflect` | Per-preference alignment breakdown + recommended action |
 | `nous_curiosity` | Explore under-retrieved, high-trust entities; writes Concerns |
 | `nous_concern` | Surface open Concerns weighted by active Preferences |
-| `nous_modify` | Create, update, or deprecate Preference nodes (gated, reason required) |
+| `nous_modify` | Create / update / deprecate Preference nodes (gated, `reason` required) |
 
-Each tool has a matching slash command — `/nous-state`, `/nous-reflect`, `/nous-curiosity`, `/nous-concern`, `/nous-modify`. See `CLAUDE.md` → "Nous Cognitive Layer — Tool Contract" for authoritative semantics and anti-sycophancy rules.
+## Skills (47)
 
-## Team Sync
+Skills are slash-invocable workflows that Claude Code can load on demand. For the full table with trigger descriptions and invocation guidance, see
+[PLUGIN_USAGE.md → Skills](PLUGIN_USAGE.md#skills-47).
 
-SIA supports team knowledge sharing via a self-hosted sqld (libSQL) server.
+Shortest path for a new user: `/sia-setup` → `/sia-tour` → start working. Sia captures automatically afterwards.
 
-### Setup
+## Agents (26)
 
-1. DevOps deploys a sqld server (see `TEAM-SYNC-DEPLOYMENT.md`)
-2. DevOps provides a server URL and auth token
-3. Developer runs: `/sia-team` → follow setup instructions
+Subagents are dispatched via `@sia-<name>`. They run as sub-sessions with their own tool grants. For the full table with *when to dispatch* and categorisation, see
+[PLUGIN_USAGE.md → Agents](PLUGIN_USAGE.md#agents-26).
 
-### Automatic Sync
+Color palette: **blue** (orient / explain), **green** (generate), **red** (debug / incident), **cyan** (quality / review), **purple** (plan / advise).
 
-| Event | Action |
+## Commands (74)
+
+Most commands are thin shims that forward to a skill or dispatch an agent. Direct MCP wrappers (e.g. `/at-time`, `/community`, `/freshness`) and the five `/nous-*` cognitive-layer commands have substantive bodies worth reading. See
+[PLUGIN_USAGE.md → Commands](PLUGIN_USAGE.md#commands-non-shim).
+
+## Hooks (9 entries across 7 events)
+
+| Event | Purpose |
 |---|---|
-| Session start | Auto-pulls latest team knowledge |
-| Session end | Auto-pushes locally captured knowledge |
-| `/sia-sync` | Manual push/pull on demand |
+| PreToolUse | Augment tool calls with graph context; Nous significance signal |
+| PostToolUse | Capture knowledge from file changes; branch-switch snapshots |
+| Stop | Detect uncaptured knowledge patterns |
+| SessionStart | Inject recent decisions + conventions |
+| PreCompact | Extract knowledge before context compaction |
+| SessionEnd | Record session statistics |
+| UserPromptSubmit | Capture prompts and detect correction/preference patterns |
 
-### Skills & Tools
-
-| Component | Purpose |
-|---|---|
-| `/sia-team` | Join, leave, or check team status (see Skills section above) |
-| `/sia-sync` | Manual push/pull operations (see Skills section above) |
-| `sia_sync_status` MCP tool | Programmatic sync status check |
+Full event matrix and authoring guidance in [hooks/README.md](hooks/README.md).
 
 ## Requirements
 

--- a/PLUGIN_USAGE.md
+++ b/PLUGIN_USAGE.md
@@ -103,7 +103,7 @@ Shortest path for a new user: `/sia-setup` → `/sia-tour` → start working nor
 | [sia-qa-flaky](skills/sia-qa-flaky/SKILL.md) | Flaky test pattern miner | CI flake triage |
 | [sia-qa-report](skills/sia-qa-report/SKILL.md) | Risk-based QA report | QA cycle kickoff |
 
-## Agents (24)
+## Agents (26)
 
 Agents are dispatched via `@sia-<name>` or their corresponding `/<name>` command. Each agent is self-contained with a `whenToUse` section, examples, and tools list.
 
@@ -116,6 +116,7 @@ Agents are dispatched via `@sia-<name>` or their corresponding `/<name>` command
 | [sia-debug-specialist](agents/sia-debug-specialist.md) | Temporal root-cause investigation | Active bug investigation |
 | [sia-decision-reviewer](agents/sia-decision-reviewer.md) | Past decisions, rejected approaches, active constraints | Before a new architectural choice |
 | [sia-dependency-tracker](agents/sia-dependency-tracker.md) | Cross-repo dependency and API-contract monitor | Workspace-level changes |
+| [sia-doc-writer](agents/sia-doc-writer.md) | Generates ADRs, README sections, module docs from captured Decisions + Conventions | Refreshing project docs; drafting an ADR |
 | [sia-explain](agents/sia-explain.md) | Explains SIA itself — entities, tools, skills, agents | User learning the plugin |
 | [sia-feature](agents/sia-feature.md) | Feature development with architectural context | New feature work |
 | [sia-knowledge-capture](agents/sia-knowledge-capture.md) | Systematic uncaptured-knowledge extraction from session | End of session |
@@ -131,6 +132,7 @@ Agents are dispatched via `@sia-<name>` or their corresponding `/<name>` command
 | [sia-qa-regression-map](agents/sia-qa-regression-map.md) | Scored regression risk table per module | Test prioritisation |
 | [sia-refactor](agents/sia-refactor.md) | Dependency-graph impact analysis | Before structural refactor |
 | [sia-regression](agents/sia-regression.md) | Regression-risk assessment of proposed changes | PR / change risk review |
+| [sia-search-debugger](agents/sia-search-debugger.md) | Diagnoses empty / off-target `sia_search` results | Search returns nothing when results are expected |
 | [sia-security-audit](agents/sia-security-audit.md) | Security review with paranoid mode and Tier 4 exposure | Security review |
 | [sia-test-advisor](agents/sia-test-advisor.md) | Test strategy from past failures + edge cases | Test-planning session |
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Sia gives your agent a typed, temporal, ontology-enforced knowledge graph that c
 /plugin install sia@sia-plugins
 ```
 
-This registers all 29 MCP tools, 47 skills, 24 agents, 9 hook entries across 7 event types, and CLAUDE.md behavioral directives in one step.
+This registers all 29 MCP tools, 47 skills, 26 agents, 9 hook entries across 7 event types, and CLAUDE.md behavioral directives in one step.
 
 > **Coming soon:** Once Sia is accepted into the official Anthropic marketplace, installation will simplify to `/plugin install sia@claude-plugins-official`.
 

--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ These nine skills augment standard development workflows with graph intelligence
 
 ---
 
-## Agents (23)
+## Agents (26)
 
 Agents are specialized subagents dispatched for focused tasks. Invoke via `@sia-<name>` (e.g., `@sia-code-reviewer`). All agents retrieve from the knowledge graph and can run simultaneously.
 
@@ -648,6 +648,7 @@ Agents are specialized subagents dispatched for focused tasks. Invoke via `@sia-
 |---|---|
 | `sia-debug-specialist` | Temporal root-cause investigation using `sia_at_time` and causal history |
 | `sia-regression` | Regression risk analysis from known bugs and failure patterns |
+| `sia-search-debugger` | Diagnoses why a `sia_search` came back empty or noisy and suggests reformulations |
 
 ### Code Review
 
@@ -662,6 +663,8 @@ Agents are specialized subagents dispatched for focused tasks. Invoke via `@sia-
 |---|---|
 | `sia-knowledge-capture` | Systematic review and capture of uncaptured session knowledge |
 | `sia-changelog-writer` | Generates changelogs from decisions, bugs fixed, and features added |
+| `sia-pr-writer` | Drafts a PR body from the branch diff + Decisions/Bugs/Solutions captured on the branch |
+| `sia-doc-writer` | Generates ADRs, README sections, and runbooks from graph state |
 
 ### QA, PM & Tech Lead
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,67 @@
+# `agents/` — Sia Subagent Library
+
+Each file in this directory defines one Claude Code subagent. Filename becomes
+the dispatch key: `agents/sia-code-reviewer.md` → `@sia-code-reviewer`.
+
+End-user dispatch guidance lives in
+[`PLUGIN_USAGE.md`](../PLUGIN_USAGE.md). This file is for contributors
+authoring new agents or modifying existing ones.
+
+## Agent file shape
+
+```markdown
+---
+name: sia-<role>
+description: One sentence the dispatcher reads to decide when to invoke.
+model: sonnet            # Always sonnet unless there is a documented reason otherwise.
+color: <palette-color>   # See palette below.
+tools: <comma-separated list of granted tools>
+whenToUse: |             # Optional but strongly encouraged — multi-example block.
+  <prose + <example> blocks>
+---
+
+# <Agent Title>
+
+<System prompt body — workflow, inputs, outputs, guardrails.>
+```
+
+## Color palette (Phase 4 semantic palette)
+
+Colors carry meaning; reuse an existing bucket rather than introducing a new one.
+
+| Color  | Meaning                                       | Example agents                                        |
+|--------|-----------------------------------------------|-------------------------------------------------------|
+| blue   | Orient / explain / onboard                    | sia-orientation, sia-onboarding, sia-explain          |
+| green  | Generator / creator (writes artifacts)        | sia-feature, sia-pr-writer, sia-changelog-writer      |
+| red    | Debug / incident / risk                       | sia-debug-specialist, sia-regression, sia-security-audit |
+| cyan   | Review / quality / compliance                 | sia-code-reviewer, sia-convention-enforcer, sia-qa-*  |
+| purple | Planning / advising / architecture            | sia-decision-reviewer, sia-refactor, sia-test-advisor |
+
+## Tool-grant conventions
+
+Grant only what the agent genuinely needs. Avoid broad grants.
+
+- **Always include** `Read, Grep, Glob, Bash` for any agent that inspects source.
+- **Retrieval agents** get `mcp__sia__sia_search`, `mcp__sia__sia_by_file`, `mcp__sia__sia_community` as needed.
+- **Writer agents** additionally get `mcp__sia__sia_note` if they should capture findings.
+- **Temporal agents** get `mcp__sia__sia_at_time` and `mcp__sia__sia_backlinks` only if the workflow reasons about history.
+- **Never grant** `nous_modify` to a subagent — the MCP tool is already blocked for subagents in-server, and the agent-local list should match.
+
+The `name:`, `description:`, and `tools:` fields are all validated by
+`scripts/validate-plugin.sh` — run the validator before committing.
+
+## Authoring a new agent
+
+1. Confirm the agent has a crisp, specific role that no existing agent covers.
+2. Copy an agent with a similar shape (`sia-pr-writer.md` is a compact template).
+3. Fill `whenToUse` with at least two `<example>` blocks showing concrete triggers.
+4. Write the system-prompt body: workflow steps, inputs, outputs, guardrails.
+5. Pick a color from the palette above.
+6. Run `bash scripts/validate-plugin.sh` — fails on missing frontmatter, bad tool names, or drift against agent counts in README / PLUGIN_README / PLUGIN_USAGE.
+7. Add a matching `commands/<name>.md` shim if users should be able to dispatch via `/<name>`.
+8. Update [`PLUGIN_USAGE.md`](../PLUGIN_USAGE.md) — add the agent to the Agents table.
+
+## Related directories
+
+- [`../commands/README.md`](../commands/README.md) — slash-command palette (many agents have matching commands).
+- [`../skills/README.md`](../skills/README.md) — skills vs agents: skills are step-by-step guides executed by the main thread; agents are sub-sessions dispatched in parallel with their own tool grants.

--- a/agents/sia-doc-writer.md
+++ b/agents/sia-doc-writer.md
@@ -1,0 +1,165 @@
+---
+name: sia-doc-writer
+description: Generates project documentation — ADRs, README sections, architecture notes — directly from captured Decisions, Conventions, and recognized Patterns in SIA's graph. Use when asked to write or refresh project docs, draft an ADR, or produce a "what does this codebase do" overview from captured knowledge.
+model: sonnet
+color: green
+tools: Read, Grep, Glob, Bash, Write, Edit, mcp__sia__sia_search, mcp__sia__sia_by_file, mcp__sia__sia_community, mcp__sia__sia_at_time
+whenToUse: |
+  Use when a developer asks you to write project documentation grounded in captured knowledge — ADRs, README sections, an architecture doc, a "what does this module do" write-up. The agent treats the graph as the authoritative source and avoids fabrication.
+
+  <example>
+  Context: User wants an ADR drafted from captured decisions.
+  user: "Write an ADR for the Redis session cache decision we made last month."
+  assistant: "I'll dispatch sia-doc-writer to pull the Decision and Conventions around that choice and format them as an ADR."
+  </example>
+
+  <example>
+  Context: User wants a README architecture section.
+  user: "The README is stale. Regenerate the 'Architecture' section from what's in the graph."
+  assistant: "Let me use sia-doc-writer — it will query the graph for module-level Decisions and community summaries and draft a fresh section."
+  </example>
+---
+
+# SIA Doc Writer — Documentation From Graph State
+
+You generate project documentation — ADRs, README sections, architecture overviews —
+grounded entirely in captured Decisions, Conventions, and community summaries in
+Sia's knowledge graph. You never invent rationale; if the graph has no relevant
+entity, you say so explicitly in the output.
+
+## Supported Document Types
+
+- **ADR (Architecture Decision Record)** — one Decision + its alternatives + context.
+- **README Architecture section** — system overview grounded in communities + key Decisions.
+- **Module / component docs** — single-module deep-dive from file-scoped entities.
+- **"What changed since <tag>"** — release-note-style prose (different from changelog; prose-first).
+
+## Workflow
+
+### Step 1: Clarify scope
+
+Confirm with the user:
+- Which document type (ADR / README section / module doc / release prose).
+- Which module, area, or decision to cover.
+- Target location (`docs/adr/NNN-<slug>.md`, `README.md`, etc.).
+
+### Step 2: Pull relevant entities from the graph
+
+Select the right retrieval strategy for the document type:
+
+**For an ADR:**
+```
+sia_search({ query: "<decision topic>", node_types: ["Decision"], limit: 5 })
+sia_search({ query: "<topic> alternatives rejected", node_types: ["Decision", "Concept"], limit: 10 })
+```
+
+**For README / architecture section:**
+```
+sia_community({ query: "architecture overview", level: 2 })
+sia_search({ query: "key architectural decisions", node_types: ["Decision"], limit: 10 })
+sia_search({ query: "coding conventions patterns", node_types: ["Convention"], limit: 10 })
+```
+
+**For module docs:**
+```
+sia_by_file({ path: "<representative file>" })
+sia_community({ query: "<module topic>", level: 1 })
+```
+
+### Step 3: Categorise entities by doc section
+
+For an ADR, sort retrieved entities into:
+- **Context** — what was being decided and why now (captured Concept entities; Decision body "context" field).
+- **Decision** — the chosen approach (Decision.name + Decision.content).
+- **Alternatives considered** — any Decisions with `supersedes` / `alternative_of` edges, or content mentioning rejected options.
+- **Consequences** — linked Conventions, known Bugs caused_by this decision, Solutions.
+
+For a README section, sort into:
+- **System overview** — Level-2 community summary.
+- **Module map** — Level-1 community names + one-line summaries.
+- **Key decisions** — top 3–5 Decisions the reader should know.
+- **Conventions to follow** — top 3–5 active Conventions.
+
+### Step 4: Draft
+
+Use the project's existing doc style if sample files exist under `docs/` — read one
+as a template and match its heading / voice. Otherwise use the MADR-lite format
+below.
+
+**ADR template:**
+
+```markdown
+# <ADR number>. <Decision title>
+
+Date: <Decision.t_valid_from or t_created>
+Status: Accepted
+
+## Context
+
+<From Decision.content "context" or a linked Concept. If no captured context exists, write "No captured context — consider running @sia-knowledge-capture to fill this in.">
+
+## Decision
+
+<Decision.content body.>
+
+## Alternatives considered
+
+<Linked rejected Decisions. For each: what it was, why rejected.>
+
+## Consequences
+
+<Linked Conventions this decision enforces. Linked Bugs caused_by this choice (if any). Solutions recorded.>
+
+## References
+
+- Sia Decision: `<entity_id>` (Tier <N>, captured <date>)
+- Related Conventions: <list of IDs>
+```
+
+**README architecture section template:**
+
+```markdown
+## Architecture
+
+<One-paragraph Level-2 community summary as prose.>
+
+### Module map
+
+| Module | What it does |
+|---|---|
+<from Level-1 community summaries>
+
+### Key decisions
+
+- **<Decision name>** — <one-line rationale>. See ADR-<N>.
+<repeat>
+
+### Conventions
+
+- <Convention name> — <one-line rule>.
+<repeat>
+```
+
+### Step 5: Write / Edit
+
+Use `Write` for new ADR files; use `Edit` for in-place README updates. Preserve
+surrounding content the user didn't ask to touch.
+
+### Step 6: Citations
+
+Every non-trivial claim in the output must cite the entity it came from — either
+inline (`per Decision <id>`) or in a final "References" block. This is what
+distinguishes graph-backed docs from generic AI prose.
+
+## Guardrails
+
+- **Never invent a rationale.** If the graph has no relevant entity, write "No captured context" — do not fabricate.
+- **Always cite Trust tier.** Tier 3 entities must be marked "(LLM-inferred — verify)" in the draft.
+- **Never overwrite user-authored sections** without explicit confirmation. If the README section you're regenerating has hand-written content not represented in the graph, surface that conflict and ask.
+- **No attribution.** Do not add "Generated by Claude" / "Co-Authored-By" / similar footers. The repo convention rejects them.
+
+## Key Principle
+
+**The graph is the source of truth.** This agent is a formatter, not an author.
+If the graph is thin, the doc will be thin — and that is the correct signal to
+the user that capture is incomplete, not an invitation to fill the gap with prose.

--- a/agents/sia-search-debugger.md
+++ b/agents/sia-search-debugger.md
@@ -2,7 +2,7 @@
 name: sia-search-debugger
 description: Diagnoses why `sia_search` returned no results or the wrong results — inspects the query terms against the actual graph, checks file-path shape, and proposes reformulated queries. Use when a search comes back empty on a codebase the user expected to have matching entities, or when results look off-target.
 model: sonnet
-color: blue
+color: red
 tools: Read, Grep, Glob, Bash, mcp__sia__sia_search, mcp__sia__sia_by_file, mcp__sia__sia_stats, mcp__sia__sia_community
 whenToUse: |
   Use when a search against Sia's graph returns nothing, too few, or the wrong results — and the user wants to know whether the graph is empty, the query is off, or the wanted knowledge was never captured.

--- a/agents/sia-search-debugger.md
+++ b/agents/sia-search-debugger.md
@@ -1,0 +1,107 @@
+---
+name: sia-search-debugger
+description: Diagnoses why `sia_search` returned no results or the wrong results — inspects the query terms against the actual graph, checks file-path shape, and proposes reformulated queries. Use when a search comes back empty on a codebase the user expected to have matching entities, or when results look off-target.
+model: sonnet
+color: blue
+tools: Read, Grep, Glob, Bash, mcp__sia__sia_search, mcp__sia__sia_by_file, mcp__sia__sia_stats, mcp__sia__sia_community
+whenToUse: |
+  Use when a search against Sia's graph returns nothing, too few, or the wrong results — and the user wants to know whether the graph is empty, the query is off, or the wanted knowledge was never captured.
+
+  <example>
+  Context: User ran a search and got zero hits on a graph they expect has content.
+  user: "I searched for 'auth middleware' and got nothing — is the graph broken?"
+  assistant: "Let me use the sia-search-debugger to diagnose — it will check whether the terms exist in the graph at all, try reformulations, and inspect the file paths you expect."
+  </example>
+
+  <example>
+  Context: Search returned results that don't match what the user expects.
+  user: "sia_search on 'payment flow' returned only one generic concept. I thought we had more there."
+  assistant: "I'll dispatch sia-search-debugger to inspect the graph for payment-related entities directly and suggest better query terms."
+  </example>
+---
+
+# SIA Search Debugger — "Why did that search return nothing?"
+
+You diagnose empty or off-target `sia_search` results. The user ran a query and got
+zero, too few, or wrong-looking hits. Your job is to figure out *why* — and propose a
+better query or confirm the knowledge was never captured.
+
+## Diagnostic Workflow
+
+### Step 1: Get the original query and expected result
+
+Ask the user (if not already provided):
+- The exact query string they ran.
+- What they expected to find — an entity name, a file path, a concept.
+- Any file paths they believe should be covered.
+
+### Step 2: Check the graph has content at all
+
+```
+sia_stats({ include_session_stats: false })
+```
+
+If node counts are near zero → the graph is empty. Stop; tell the user to run `/sia-learn`.
+
+### Step 3: Run the original query yourself and compare
+
+```
+sia_search({ query: "<original>", limit: 20 })
+```
+
+Check:
+- Result count — same as what the user saw?
+- Top result types — are they off-domain (e.g., searching "auth" returned only `Concept` when the user wanted `Decision`)?
+- Trust tiers — all Tier 3? Maybe the knowledge was captured but low confidence.
+
+### Step 4: File-path sanity check
+
+If the user mentioned a specific file:
+
+```
+sia_by_file({ path: "<path>" })
+```
+
+If that returns nothing, the file isn't indexed — either the learn hasn't run over it, it's gitignored, or the path is wrong (case mismatch, wrong extension).
+
+### Step 5: Reformulate the query and re-run
+
+Try up to three reformulations. Good reformulations:
+- **Broader terms** — `"auth middleware"` → `"authentication"`
+- **Domain synonyms** — `"payment flow"` → `"billing pipeline"` / `"checkout"` / `"stripe"`
+- **Entity-type narrowing** — add `node_types: ["Decision"]` or `["Convention"]` instead of an open search.
+- **File-scoped search** — try `sia_by_file` on a likely implementation file.
+
+```
+sia_search({ query: "<reformulated>", node_types: [...], limit: 10 })
+```
+
+### Step 6: Community probe (only if graph is large)
+
+If the codebase has ≥ 100 entities and targeted searches fail:
+
+```
+sia_community({ query: "<topic>", level: 1 })
+```
+
+A community summary will surface whether the topic area exists at all as a cluster,
+even if individual entity names don't match the query terms.
+
+### Step 7: Report
+
+Close with one of these verdicts:
+
+- **Graph empty** — "The graph has no entities. Run `/sia-learn` first."
+- **Query off-target** — "The entities exist; the query terms were too narrow / used a different vocabulary. Try: `<reformulated query>` or `sia_by_file(<path>)`."
+- **Knowledge not captured** — "The graph has entities but nothing matches this topic. This is a knowledge-capture gap, not a search failure. Consider running `@sia-knowledge-capture` or adding a Decision via `sia_note`."
+- **Trust-tier filter** — "Results exist but all at Tier 3 (LLM-inferred). The user may have a trust-tier filter applied, or the area relies on probabilistic capture; consider manually capturing a Tier 1 Decision."
+
+Be explicit about which verdict applies. Show the reformulated query the user should copy-paste.
+
+## Tool Budget
+
+At most 5 tool calls total: `sia_stats` (1) + `sia_search` (2) + up to 2 reformulated `sia_search` (3–4) + optional `sia_community` or `sia_by_file` (5). Stop early once the verdict is clear.
+
+## Key Principle
+
+**Empty search results are rarely bugs.** 95% of the time they indicate a vocabulary mismatch or a capture gap. Diagnose the cause; don't paper over it.

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,0 +1,61 @@
+# `commands/` — Slash Command Palette
+
+This directory holds every user-facing `/command` shipped by the Sia plugin.
+Each file here becomes a single Claude Code slash command. The filename
+(without `.md`) is the command name: `commands/search.md` → `/search`.
+
+For end-user usage of each command, see
+[`PLUGIN_USAGE.md`](../PLUGIN_USAGE.md). This file is for contributors
+authoring or editing commands.
+
+## What a command file contains
+
+Every command file has YAML frontmatter and a body:
+
+```markdown
+---
+description: One-line summary shown in the palette.
+argument-hint: <query>               # Only if the body references $ARGUMENTS or $1
+---
+
+Body — either forwards to a skill, dispatches an agent, or invokes an MCP tool.
+```
+
+### Frontmatter fields
+
+| Field           | Required | Notes                                                                    |
+|-----------------|----------|--------------------------------------------------------------------------|
+| `description`   | Yes      | Present tense, < 80 chars, no trailing period.                           |
+| `argument-hint` | Conditional | **MUST** be present if the body references `$ARGUMENTS` or `$1`.      |
+
+## Three command shapes
+
+Commands fall into one of three patterns:
+
+1. **Skill shim** — forwards to a skill with the same semantic name.
+   ```
+   Run the `/sia-<name>` skill.
+   ```
+
+2. **Agent-dispatch shim** — dispatches an agent with a one-line flavor note.
+   ```
+   Dispatch the `@sia-<name>` agent. See [`agents/sia-<name>.md`](../agents/sia-<name>.md) — at a glance: <one line>.
+   ```
+
+3. **Direct MCP wrapper** — calls an MCP tool directly, usually with arguments.
+   Examples: `at-time.md`, `community.md`, `freshness.md`, the five `nous-*` commands.
+   These contain richer guidance and worked examples.
+
+## Authoring a new command
+
+1. Decide the shape — does an existing skill or agent already do this? If yes, shim it.
+2. Add `commands/<name>.md` with correct frontmatter.
+3. If the body uses `$ARGUMENTS` or `$1`, add `argument-hint:` to the frontmatter.
+4. Run `bash scripts/validate-plugin.sh` — the validator checks frontmatter shape and counts.
+5. Update [`PLUGIN_USAGE.md`](../PLUGIN_USAGE.md) if the new command adds a user-facing workflow worth surfacing (direct MCP wrappers usually do; shims usually don't).
+
+## Related directories
+
+- [`../skills/README.md`](../skills/README.md) — the skills layer that most commands shim to.
+- [`../agents/README.md`](../agents/README.md) — the agents layer that `*-agent` commands dispatch to.
+- [`../hooks/README.md`](../hooks/README.md) — automatic hook handlers (not user-invocable).

--- a/commands/doc-writer.md
+++ b/commands/doc-writer.md
@@ -1,0 +1,5 @@
+---
+description: Generate ADRs, README sections, and module docs from captured Decisions and Conventions
+---
+
+Dispatch the `@sia-doc-writer` agent. See [`agents/sia-doc-writer.md`](../agents/sia-doc-writer.md) — at a glance: formats Decisions, Conventions, and community summaries into ADRs, README architecture sections, or module documentation, with citations and no fabricated rationale.

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -1,5 +1,6 @@
 ---
 description: Build or refresh SIA's complete knowledge graph — indexes code, docs, and communities
+argument-hint: "[--incremental|--full|--docs-only] (optional)"
 ---
 
 Run the `/sia-learn` skill. Pass through any arguments: $ARGUMENTS

--- a/commands/search-debugger.md
+++ b/commands/search-debugger.md
@@ -1,0 +1,5 @@
+---
+description: Diagnose why a `sia_search` returned nothing or the wrong results
+---
+
+Dispatch the `@sia-search-debugger` agent. See [`agents/sia-search-debugger.md`](../agents/sia-search-debugger.md) — at a glance: inspects the query terms against the real graph, tries reformulations, and reports whether the graph is empty, the vocabulary is off, or the knowledge simply isn't captured.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,71 @@
+# `hooks/` — Claude Code Hook Registrations
+
+This directory contains `hooks.json`, which registers every hook handler the
+Sia plugin attaches to Claude Code's lifecycle. The actual handler scripts live
+in [`../scripts/`](../scripts/) (shell wrappers) and
+[`../src/hooks/`](../src/hooks/) (TypeScript handlers).
+
+End users do not invoke hooks directly — they fire automatically. This file is
+for contributors who need to add, modify, or debug a hook.
+
+## Event matrix
+
+Current registrations (see [`hooks.json`](hooks.json) for the source of truth):
+
+| Event             | Matcher           | Handler                              | Timeout | Purpose                                             |
+|-------------------|-------------------|--------------------------------------|---------|-----------------------------------------------------|
+| PreToolUse        | `Grep\|Glob\|Bash` | `src/hooks/augment-hook.ts`          | 7s      | Enrich tool calls with graph context                |
+| PreToolUse        | `""` (all)        | `scripts/pre-tool-use.sh`            | 3s      | Nous PreToolUse significance signal                 |
+| PostToolUse       | `Write\|Edit\|Read` | `scripts/post-tool-use.sh`          | 5s      | Capture knowledge from file changes; file-read context |
+| PostToolUse       | `Bash`            | `scripts/branch-switch.sh`           | 10s     | Detect branch switches; save/restore graph snapshots |
+| Stop              | `""`              | `scripts/stop-hook.sh`               | 10s     | Detect uncaptured knowledge patterns                |
+| SessionStart      | `""`              | `scripts/session-start.sh`           | 5s      | Inject recent decisions and conventions             |
+| PreCompact        | `""`              | `scripts/pre-compact.sh`             | 10s     | Extract knowledge before context compaction        |
+| SessionEnd        | `""`              | `scripts/session-end.sh`             | 10s     | Record session statistics and entity counts        |
+| UserPromptSubmit  | `""`              | `scripts/user-prompt-submit.sh`      | 5s      | Capture prompts; detect correction/preference patterns |
+
+PreToolUse registers **two** parallel handlers intentionally (see the `_comment`
+at the top of `hooks.json`). Do not collapse them.
+
+## Handler conventions
+
+- **Shell wrappers** (`scripts/*.sh`) are thin: they set up environment variables,
+  locate bun, and `exec` the TypeScript handler. Keep logic out of the wrapper.
+- **TypeScript handlers** (`src/hooks/*.ts`) take the hook event JSON on stdin,
+  perform work, and exit. They must never block indefinitely — always respect the
+  declared timeout.
+- **Exit codes** — non-zero exit aborts the tool call for PreToolUse hooks. Only
+  return non-zero when the hook intends to block. Log to stderr; return 0 by default.
+- **Data paths** — read/write under `${SIA_HOME}` / `${CLAUDE_PLUGIN_DATA}`.
+  Never write to `${CLAUDE_PLUGIN_ROOT}` (it's read-only in user installs).
+- **Portability** — use `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_DATA}`,
+  never hard-coded paths. The validator
+  (`bash scripts/validate-plugin.sh`) catches portability violations.
+
+## Timeout guidance
+
+Picking a timeout is a tradeoff between correctness and UX. Guidelines:
+
+- **PreToolUse** — keep under 7s. The user is waiting for a tool call to run.
+  Prefer to degrade gracefully (skip augmentation) rather than stall the tool.
+- **PostToolUse** — up to 10s is acceptable for batch captures; typical hooks finish in under 5s.
+- **Stop / SessionEnd / PreCompact** — up to 10s. The session is already ending or pausing;
+  the user is less sensitive here.
+- **If a handler can't reliably complete in its budget**, move work to a background
+  process or offload to the next session's SessionStart. Never raise a timeout to "fix" flakiness.
+
+## Adding a new hook
+
+1. Decide the event and matcher (see the Claude Code hook reference for supported events).
+2. Add the registration to `hooks.json`. The validator enforces that every
+   registered handler actually exists on disk.
+3. Create the handler script (ideally a shell wrapper + TS handler pair).
+4. Add a unit test under [`../tests/hooks/`](../tests/hooks/) exercising the handler with representative stdin.
+5. Run `bash scripts/validate-plugin.sh` and `bun run test`.
+6. Update this file's event matrix.
+
+## Related directories
+
+- [`../scripts/`](../scripts/) — shell wrappers invoked by `hooks.json`.
+- [`../src/hooks/`](../src/hooks/) — TypeScript handlers.
+- [`../tests/hooks/`](../tests/hooks/) — hook unit and integration tests.

--- a/scripts/count-plugin-components.sh
+++ b/scripts/count-plugin-components.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 skills=$( { ls -d skills/*/ 2>/dev/null || true; } | wc -l | tr -d ' ')
-agents=$( { ls agents/*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
-commands=$( { ls commands/*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+# Exclude README.md — it documents the directory, it is not itself an agent / command.
+agents=$( { ls agents/*.md 2>/dev/null | grep -v '/README\.md$' || true; } | wc -l | tr -d ' ')
+commands=$( { ls commands/*.md 2>/dev/null | grep -v '/README\.md$' || true; } | wc -l | tr -d ' ')
 mcp_tools=$( { grep -oE '"(sia_|nous_)[a-z_]+"' src/mcp/server.ts 2>/dev/null || true; } | sort -u | wc -l | tr -d ' ')
 hook_entries=$(jq '[.hooks | to_entries[] | .value[]] | length' hooks/hooks.json 2>/dev/null || echo 0)
 hook_events=$(jq '.hooks | keys | length' hooks/hooks.json 2>/dev/null || echo 0)

--- a/scripts/generate-plugin-usage.sh
+++ b/scripts/generate-plugin-usage.sh
@@ -83,6 +83,7 @@ print_agents_table() {
   echo "|---|---|---|"
   for f in agents/*.md; do
     [[ -f "$f" ]] || continue
+    [[ "$(basename "$f")" == "README.md" ]] && continue
     local name
     name=$(basename "$f" .md)
     local desc
@@ -103,6 +104,7 @@ print_commands_table() {
   echo "|---|---|---|---|"
   for f in commands/*.md; do
     [[ -f "$f" ]] || continue
+    [[ "$(basename "$f")" == "README.md" ]] && continue
     local name
     name=$(basename "$f" .md)
     local desc
@@ -155,6 +157,7 @@ if [[ "$MODE" == "verify" ]]; then
     fi
   done
   for f in agents/*.md; do
+    [[ "$(basename "$f")" == "README.md" ]] && continue
     name=$(basename "$f" .md)
     if ! grep -Eq "(^|[^A-Za-z0-9_-])${name}([^A-Za-z0-9_-]|$)" "$target"; then
       echo "drift: agent '$name' not listed in $target" >&2

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -292,6 +292,8 @@ check_agents() {
 		[[ -f "$f" ]] || continue
 		local fname
 		fname="$(basename "$f")"
+		# README.md documents the directory, not an agent.
+		[[ "$fname" == "README.md" ]] && continue
 
 		# Extract the frontmatter block between the first two `---` lines.
 		local fm
@@ -415,6 +417,8 @@ check_commands() {
 	local f
 	for f in commands/*.md; do
 		[[ -f "$f" ]] || continue
+		# README.md documents the directory, not a command.
+		[[ "$(basename "$f")" == "README.md" ]] && continue
 		local fm
 		fm=$(awk '
 			/^---[[:space:]]*$/ { c++; if (c == 2) exit; next }

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,74 @@
+# `skills/` — Sia Skill Library
+
+Each subdirectory contains one skill: `skills/<skill-name>/SKILL.md`. The
+skill name is what the user invokes: `skills/sia-search/` → `/sia-search`.
+Skills may include additional reference files (e.g., the contextual playbooks
+under `skills/sia-playbooks/`).
+
+End-user invocation guidance lives in
+[`PLUGIN_USAGE.md`](../PLUGIN_USAGE.md). This file is for contributors
+authoring skills.
+
+## Skill file shape
+
+Every skill ships a `SKILL.md` with YAML frontmatter and a body:
+
+```markdown
+---
+name: sia-<workflow>
+description: <TRIGGER-STYLE description — see style guide below>
+---
+
+# <Skill Title>
+
+<Body — step-by-step guide the main Claude thread follows when the skill is loaded.>
+```
+
+## Trigger-style description — style guide (Phase 2)
+
+The `description` field is what the skill router reads to decide *when* to auto-load
+a skill. A good description names the capability **and** the triggering conditions.
+
+- **Start with a capability verb in present tense**: "Searches", "Guides", "Generates", "Compares".
+- **Name the triggering conditions explicitly** — the router is a keyword matcher.
+  Include phrases like "Use when the user asks...", "Use when conflicts exist...",
+  "Use at end of session...". The more specific the trigger phrase, the less routing drift.
+- **Avoid marketing copy** ("powerful", "seamless"). Be mechanical.
+- Aim for 1–3 sentences, under ~300 characters.
+
+Good:
+> Lists and resolves knowledge conflicts in the SIA graph where multiple entities contradict each other. Use when conflict_group_id appears in results, or when the user asks about contradictions in captured knowledge.
+
+Bad:
+> A powerful conflict resolution tool for handling knowledge issues.
+
+## Skills vs agents vs commands
+
+| Layer    | Runs in                       | Has tool grants? | Typical scope                                      |
+|----------|-------------------------------|------------------|----------------------------------------------------|
+| Skill    | The main Claude thread        | Inherits thread  | Multi-step workflow guides loaded on demand        |
+| Agent    | A spawned subagent            | Explicit         | Parallel / specialized sub-session with its own tools |
+| Command  | User-invoked entry point      | N/A              | A `/slash` shortcut that forwards to skill or agent |
+
+If the workflow is "do this sequence of steps in the current thread," author a skill.
+If it benefits from its own tool grants and can run in parallel with the main work,
+author an agent instead.
+
+## Authoring a new skill
+
+1. Check [`PLUGIN_USAGE.md`](../PLUGIN_USAGE.md) — does an existing skill already cover this?
+2. Create `skills/<name>/SKILL.md` with the frontmatter shape above.
+3. Write the trigger-style description following the guide above.
+4. Author the body as a numbered step-by-step guide that the agent will *follow*,
+   not as abstract documentation. Bias toward concrete tool calls.
+5. If the skill needs reference material, add sibling files under `skills/<name>/`
+   (e.g., `reference-*.md`) and link to them from SKILL.md.
+6. Run `bash scripts/validate-plugin.sh` — fails on missing frontmatter or count drift.
+7. Add a matching `commands/<name>.md` shim if the skill should be user-invocable by a shorter alias.
+8. Update [`PLUGIN_USAGE.md`](../PLUGIN_USAGE.md) to list the new skill with its *when-to-invoke* trigger.
+
+## Related directories
+
+- [`../commands/README.md`](../commands/README.md) — slash-command shims that forward to skills.
+- [`../agents/README.md`](../agents/README.md) — subagents (for parallel, tool-scoped work).
+- [`sia-playbooks/`](sia-playbooks/) — contextual playbooks loaded by CLAUDE.md based on task classification.


### PR DESCRIPTION
## Summary

**Final phase** of the plugin polish plan. Minor version bump — new user-visible agents = new capability.

### Added

- **Two new agents** (+ matching shim commands):
  - `sia-search-debugger` (red, diagnostic) — diagnoses why `sia_search` returned no results or the wrong results; inspects query terms, checks file-path shape, proposes reformulations.
  - `sia-doc-writer` (green, generator) — drafts ADRs, README sections, and runbooks from graph state (Decisions + Conventions + Patterns). Differentiates from `sia-changelog-writer` (release notes) by producing narrative-first prose.
- **Four component-directory READMEs** for contributors (not end users — those are in `PLUGIN_USAGE.md`):
  - `commands/README.md` — command authoring guide + shim conventions
  - `agents/README.md` — agent authoring guide + color palette
  - `skills/README.md` — skill authoring guide + description contract
  - `hooks/README.md` — event matrix + handler conventions + timeout guidance

### Changed

- **`PLUGIN_README.md` slimmed 267 → 98 lines.** Now a pure quick-reference card: install + 29-row MCP tool table + pointer rows to README / CLAUDE / PLUGIN_USAGE / CONTRIBUTING / SECURITY. All duplicated prose removed.
- **`commands/learn.md` gained `argument-hint`.** The sweep identified this as the only command accepting args without declaring them.
- **`README.md` `## Agents (23)` → `## Agents (26)`** and three new agent rows added (caught by post-review — the counts regex missed the parenthesised shape).

### Skipped / deferred (spec authorized)

- **7.3 Command pruning** (73 → ~40). Every shim in the palette is a shorter alias (`/search` → `/sia-search`), not a duplicate. Without a principled rule distinguishing aliases from duplicates, any cut would break user muscle memory. Deferred to Phase 8.
- **7.5 Inline `mcpServers` into plugin.json**. Current `.mcp.json` at repo root is auto-discovered and verified working. Inlining needs a dedicated verification session; spec's "better to NOT ship a break" clause applied.

## Test plan

- [x] `bun run test` — 2025/2025 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx @biomejs/biome check .` — 559 files, 0 errors
- [x] `bash scripts/validate-plugin.sh` — OK (9/9 checks)
- [x] `bash scripts/count-plugin-components.sh` — **47 skills / 26 agents / 74 commands** / 29 MCP tools / 9 hook entries / 7 hook events
- [x] No `src/` changes (pure docs + new agents)
- [x] No Co-Authored-By / Claude attribution

## Commits

- `1a96e22` — component-dir READMEs + argument-hint on learn
- `bbd9750` — sia-search-debugger + sia-doc-writer + shim commands
- `989a75a` — PLUGIN_README slim to quick-reference card
- `2112246` — v1.2.0 bump + CHANGELOG
- `976d1f5` — post-review: search-debugger red palette, README Agents (23)→(26) + 3 missing rows