### PR TITLE
chore(plugin): prune command palette 74 → 40; v1.2.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.2.2"
+		"version": "1.2.3"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.2.2",
+			"version": "1.2.3",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.2.2"
+	"version": "1.2.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,76 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-04-21
+
+### Removed
+
+Command palette pruned 74 → 40. Every cut command's functionality remains
+reachable — skills as `/sia-<name>`, agents as `@sia-<name>`. Only the
+short-alias slash shim was removed.
+
+**Skill shim aliases (18):** `/compare`, `/export`, `/export-import`,
+`/history`, `/impact`, `/index`, `/playbooks`, `/pm-decision-log`,
+`/pm-risk-dashboard`, `/pm-sprint-summary`, `/prune`, `/qa-coverage`,
+`/qa-flaky`, `/qa-report`, `/reindex`, `/review-respond`, `/team`,
+`/visualize-live`.
+
+**Agent delegation shims (16):** `/changelog-writer`, `/conflict-resolver`,
+`/convention-enforcer`, `/decision-reviewer`, `/dependency-tracker`,
+`/doc-writer`, `/feature`, `/lead-architecture-advisor`,
+`/lead-team-health`, `/migration`, `/pm-briefing`, `/pm-risk-advisor`,
+`/qa-analyst`, `/qa-regression-map`, `/search-debugger`, `/test-advisor`.
+
+### Changed
+
+- **Pruning rule (adopted 1.2.3, open for team debate).** Phase 7 deferred
+  this cut because no principled rule distinguished a palette-worthy alias
+  from clutter. The rule applied here:
+
+  > **KEEP a command if ANY of:**
+  >
+  > 1. It takes arguments (`argument-hint:` in frontmatter) — the short
+  >    alias carries ergonomic value that `/sia-<name>` cannot replicate
+  >    without more typing per invocation.
+  > 2. It wraps an MCP tool directly (non-shim body that invokes a tool
+  >    like `sia_at_time` or `sia_community`) — no corresponding `/sia-X`
+  >    skill exists to absorb the command.
+  > 3. It is one of the five `/nous-*` cognitive-layer commands —
+  >    CLAUDE.md's Nous Tool Contract references these by name as the
+  >    canonical slash interface.
+  > 4. It is a high-frequency daily-workflow short alias where the short
+  >    form provides real discoverability value — the curated set is
+  >    `/setup`, `/install`, `/doctor`, `/tour`, `/stats`, `/status`,
+  >    `/capture`, `/learn`, `/search`, `/debug`, `/plan`, `/test`,
+  >    `/verify`, `/upgrade`, `/finish`, `/brainstorm`, `/execute`,
+  >    `/execute-plan`, `/dispatch`, `/conflicts`, `/freshness`,
+  >    `/digest`, `/workspace`, `/sync`, plus the agent-canonical
+  >    entries `/code-reviewer`, `/pr-writer`, `/refactor`,
+  >    `/regression`, `/security-audit`, `/knowledge-capture`,
+  >    `/onboarding`, `/orientation`, `/explain`.
+  >
+  > **CUT a command if ALL of:**
+  >
+  > 1. It is a 2-line shim with no `$ARGUMENTS` handling.
+  > 2. A `/sia-<name>` skill or `@sia-<name>` agent already autocompletes
+  >    from the palette.
+  > 3. It is not in the daily-workflow curation list above.
+  > 4. It is not an MCP-direct or Nous-layer command.
+
+  Rationale: the starting heuristic — "cut any alias whose name is a
+  prefix of the canonical `/sia-<name>`" — is too mechanical. It would
+  cut `/search` and `/setup` despite those being the highest-frequency
+  entries. The refined rule is explicit about which high-frequency
+  aliases get protected, so the cut list is defensible rather than
+  arbitrary.
+
+- `PLUGIN_USAGE.md` — "Commands (non-shim)" section rewritten as
+  "Commands (40)" with three tables (MCP wrappers, Nous layer, short
+  aliases) plus an agent-canonical table. Every retained command is
+  now listed with its forwarding target.
+- `PLUGIN_README.md` — command count updated 74 → 40 with a pointer to
+  the pruning rule in this CHANGELOG entry.
+
 ## [1.2.2] - 2026-04-21
 
 ### Changed

--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -68,10 +68,10 @@ Subagents are dispatched via `@sia-<name>`. They run as sub-sessions with their 
 
 Color palette: **blue** (orient / explain), **green** (generate), **red** (debug / incident), **cyan** (quality / review), **purple** (plan / advise).
 
-## Commands (74)
+## Commands (40)
 
-Most commands are thin shims that forward to a skill or dispatch an agent. Direct MCP wrappers (e.g. `/at-time`, `/community`, `/freshness`) and the five `/nous-*` cognitive-layer commands have substantive bodies worth reading. See
-[PLUGIN_USAGE.md → Commands](PLUGIN_USAGE.md#commands-non-shim).
+Pruned from 74 in 1.2.1. Kept: direct MCP wrappers (`/at-time`, `/community`), the five `/nous-*` cognitive-layer commands, args-bearing shims (`/search`, `/learn`), and high-frequency short aliases (`/setup`, `/doctor`, `/capture`, `/debug`, etc.). All other skills and agents remain reachable as `/sia-<name>` and `@sia-<name>`. See
+[PLUGIN_USAGE.md → Commands](PLUGIN_USAGE.md#commands-40) and the 1.2.1 CHANGELOG entry for the full pruning rule.
 
 ## Hooks (9 entries across 7 events)
 

--- a/PLUGIN_USAGE.md
+++ b/PLUGIN_USAGE.md
@@ -136,9 +136,9 @@ Agents are dispatched via `@sia-<name>` or their corresponding `/<name>` command
 | [sia-security-audit](agents/sia-security-audit.md) | Security review with paranoid mode and Tier 4 exposure | Security review |
 | [sia-test-advisor](agents/sia-test-advisor.md) | Test strategy from past failures + edge cases | Test-planning session |
 
-## Commands (non-shim)
+## Commands (40)
 
-Most commands are thin shims that forward to a skill (`Run the /sia-X skill`) or dispatch an agent (`Dispatch the @sia-Y agent`). The ones below have substantive bodies worth reading directly:
+The command palette was pruned in 1.2.1 from 74 → 40 under a principled rule: keep a command if it takes arguments, wraps an MCP tool directly, is part of the Nous cognitive layer, or is a high-frequency daily-workflow short alias. Otherwise the canonical `/sia-<name>` skill or `@sia-<name>` agent is the entry point (both autocomplete from the palette). See [CHANGELOG.md](CHANGELOG.md#121---2026-04-21) for the rule in full and the cut list.
 
 ### Direct MCP wrappers
 
@@ -146,7 +146,6 @@ Most commands are thin shims that forward to a skill (`Run the /sia-X skill`) or
 |---|---|
 | [/at-time](commands/at-time.md) | Query graph state at a past timestamp |
 | [/community](commands/community.md) | Inspect community partitioning at a level |
-| [/freshness](commands/freshness.md) | Run the freshness engine |
 
 ### Nous cognitive layer
 
@@ -158,9 +157,52 @@ Most commands are thin shims that forward to a skill (`Run the /sia-X skill`) or
 | [/nous-concern](commands/nous-concern.md) | Surface open Concern nodes as prioritised insights |
 | [/nous-modify](commands/nous-modify.md) | Create / update / deprecate a Preference node (always requires a reason) |
 
-### Agent-delegation commands
+### Short aliases (daily workflow)
 
-The remaining non-shim commands dispatch agents. Each has a one-line summary of the agent plus a link to its full definition — see `commands/*.md`. The full agent list is in the Agents table above.
+Every command below is a 2-line shim forwarding to the matching `/sia-<name>` skill or `@sia-<name>` agent; the short form is kept for palette ergonomics. Pass-through arg examples: `/search <query>`, `/learn --incremental`.
+
+| Command | Forwards to | When to use |
+|---|---|---|
+| [/setup](commands/setup.md) | `/sia-setup` skill | First-run bootstrap |
+| [/install](commands/install.md) | `/sia-install` skill | DB scaffold, no indexing |
+| [/learn](commands/learn.md) | `/sia-learn` skill | Build / refresh the graph |
+| [/search](commands/search.md) | `/sia-search` skill | Hybrid graph retrieval |
+| [/capture](commands/capture.md) | `/sia-capture` skill | End-of-session knowledge capture |
+| [/tour](commands/tour.md) | `/sia-tour` skill | Guided graph tour |
+| [/doctor](commands/doctor.md) | `/sia-doctor` skill | System health check |
+| [/stats](commands/stats.md) | `/sia-stats` skill | Graph size / growth stats |
+| [/status](commands/status.md) | `/sia-status` skill | Capture rate, conflicts dashboard |
+| [/upgrade](commands/upgrade.md) | `/sia-upgrade` skill | Self-update |
+| [/finish](commands/finish.md) | `/sia-finish` skill | Wrap up a branch |
+| [/debug](commands/debug.md) | `/sia-debug-workflow` skill | Temporal root-cause tracing |
+| [/plan](commands/plan.md) | `/sia-plan` skill | Implementation plan with graph context |
+| [/test](commands/test.md) | `/sia-test` skill | Graph-informed TDD |
+| [/verify](commands/verify.md) | `/sia-verify` skill | Area-specific verification gate |
+| [/brainstorm](commands/brainstorm.md) | `/sia-brainstorm` skill | Pre-loaded design dialogue |
+| [/execute](commands/execute.md) | `/sia-execute` skill | Sandboxed code execution |
+| [/execute-plan](commands/execute-plan.md) | `/sia-execute-plan` skill | Plan execution with staleness detection |
+| [/dispatch](commands/dispatch.md) | `/sia-dispatch` skill | Parallel agent dispatch |
+| [/conflicts](commands/conflicts.md) | `/sia-conflicts` skill | List / resolve graph conflicts |
+| [/freshness](commands/freshness.md) | `/sia-freshness` skill | Fresh / stale / rotten scan |
+| [/digest](commands/digest.md) | `/sia-digest` skill | 24-hour knowledge digest |
+| [/workspace](commands/workspace.md) | `/sia-workspace` skill | Multi-repo workspace |
+| [/sync](commands/sync.md) | `/sia-sync` skill | Manual team knowledge push/pull |
+
+### Agent-canonical slash entries
+
+The short alias is kept for the highest-frequency agent dispatches; all other agents are reachable as `@sia-<name>` directly. See the [Agents table](#agents-26) for the full list.
+
+| Command | Dispatches | When to dispatch |
+|---|---|---|
+| [/code-reviewer](commands/code-reviewer.md) | `@sia-code-reviewer` | PR review with historical + convention context |
+| [/pr-writer](commands/pr-writer.md) | `@sia-pr-writer` | Draft a PR body from captured Decisions / Bugs |
+| [/refactor](commands/refactor.md) | `@sia-refactor` | Dependency-graph impact analysis |
+| [/regression](commands/regression.md) | `@sia-regression` | Regression-risk assessment |
+| [/security-audit](commands/security-audit.md) | `@sia-security-audit` | Paranoid-mode security review |
+| [/knowledge-capture](commands/knowledge-capture.md) | `@sia-knowledge-capture` | Systematic session-level knowledge extraction |
+| [/onboarding](commands/onboarding.md) | `@sia-onboarding` | Full multi-topic onboarding session |
+| [/orientation](commands/orientation.md) | `@sia-orientation` | Quick single-answer architecture Q&A |
+| [/explain](commands/explain.md) | `@sia-explain` | Explains SIA itself — entities, tools, skills, agents |
 
 ---
 

--- a/commands/changelog-writer.md
+++ b/commands/changelog-writer.md
@@ -1,5 +1,0 @@
----
-description: Generate changelogs and release notes from SIA's knowledge graph
----
-
-Dispatch the `@sia-changelog-writer` agent. See [`agents/sia-changelog-writer.md`](../agents/sia-changelog-writer.md) — at a glance: pulls Decisions, Bugs fixed, features added, and Conventions established since a given date or tag and formats them as Keep-a-Changelog-style release notes.

--- a/commands/compare.md
+++ b/commands/compare.md
@@ -1,5 +1,0 @@
----
-description: Compare knowledge graph state between two time points
----
-
-Run the `/sia-compare` skill. 

--- a/commands/conflict-resolver.md
+++ b/commands/conflict-resolver.md
@@ -1,5 +1,0 @@
----
-description: Resolve conflicting knowledge in the graph — walk through evidence and choose
----
-
-Dispatch the `@sia-conflict-resolver` agent. See [`agents/sia-conflict-resolver.md`](../agents/sia-conflict-resolver.md) — at a glance: walks the developer through each active conflict group, presents the competing entities with provenance and timestamps, and applies the chosen resolution (keep one, invalidate others).

--- a/commands/convention-enforcer.md
+++ b/commands/convention-enforcer.md
@@ -1,5 +1,0 @@
----
-description: Check code changes against all known conventions and flag violations
----
-
-Dispatch the `@sia-convention-enforcer` agent. See [`agents/sia-convention-enforcer.md`](../agents/sia-convention-enforcer.md) — at a glance: scans the current diff against every active Convention entity and flags violations. Lighter than a full code review — focused purely on convention compliance.

--- a/commands/decision-reviewer.md
+++ b/commands/decision-reviewer.md
@@ -1,5 +1,0 @@
----
-description: Surface past architectural decisions, rejected approaches, and constraints
----
-
-Dispatch the `@sia-decision-reviewer` agent. See [`agents/sia-decision-reviewer.md`](../agents/sia-decision-reviewer.md) — at a glance: surfaces past architectural decisions in the target area, what was tried and rejected, and active constraints. Run before making a new architectural choice to avoid repeating failed approaches.

--- a/commands/dependency-tracker.md
+++ b/commands/dependency-tracker.md
@@ -1,5 +1,0 @@
----
-description: Monitor cross-repo dependencies and detect breaking API changes
----
-
-Dispatch the `@sia-dependency-tracker` agent. See [`agents/sia-dependency-tracker.md`](../agents/sia-dependency-tracker.md) — at a glance: monitors cross-repo and cross-package dependencies via bridge edges, flags API contract changes, and detects breaking changes that cross repo boundaries in a workspace.

--- a/commands/doc-writer.md
+++ b/commands/doc-writer.md
@@ -1,5 +1,0 @@
----
-description: Generate ADRs, README sections, and module docs from captured Decisions and Conventions
----
-
-Dispatch the `@sia-doc-writer` agent. See [`agents/sia-doc-writer.md`](../agents/sia-doc-writer.md) — at a glance: formats Decisions, Conventions, and community summaries into ADRs, README architecture sections, or module documentation, with citations and no fabricated rationale.

--- a/commands/export-import.md
+++ b/commands/export-import.md
@@ -1,5 +1,0 @@
----
-description: Export and import knowledge graphs as portable JSON
----
-
-Run the `/sia-export-import` skill. 

--- a/commands/export.md
+++ b/commands/export.md
@@ -1,5 +1,0 @@
----
-description: Export knowledge graph as human-readable KNOWLEDGE.md for sharing or onboarding
----
-
-Run the `/sia-export-knowledge` skill.

--- a/commands/feature.md
+++ b/commands/feature.md
@@ -1,5 +1,0 @@
----
-description: Feature development with architectural context and convention compliance
----
-
-Dispatch the `@sia-feature` agent. See [`agents/sia-feature.md`](../agents/sia-feature.md) — at a glance: assists with feature development by pre-loading architectural context, dependency awareness, and convention compliance checks from the graph.

--- a/commands/history.md
+++ b/commands/history.md
@@ -1,5 +1,0 @@
----
-description: Explore how the knowledge graph evolved over time
----
-
-Run the `/sia-history` skill. 

--- a/commands/impact.md
+++ b/commands/impact.md
@@ -1,5 +1,0 @@
----
-description: Analyze impact of a planned code change — dependencies, callers, downstream effects
----
-
-Run the `/sia-impact` skill.

--- a/commands/index.md
+++ b/commands/index.md
@@ -1,5 +1,0 @@
----
-description: Index external content into the knowledge graph — markdown, URLs, documents
----
-
-Run the `/sia-index` skill. 

--- a/commands/lead-architecture-advisor.md
+++ b/commands/lead-architecture-advisor.md
@@ -1,5 +1,0 @@
----
-description: Detect architecture drift against captured decisions
----
-
-Dispatch the `@sia-lead-architecture-advisor` agent. See [`agents/sia-lead-architecture-advisor.md`](../agents/sia-lead-architecture-advisor.md) — at a glance: compares current code structure against captured Decision entities and surfaces modules where the codebase has drifted from intended design.

--- a/commands/lead-team-health.md
+++ b/commands/lead-team-health.md
@@ -1,5 +1,0 @@
----
-description: Analyze team knowledge health — coverage gaps and bus-factor risks
----
-
-Dispatch the `@sia-lead-team-health` agent. See [`agents/sia-lead-team-health.md`](../agents/sia-lead-team-health.md) — at a glance: analyses knowledge distribution across modules, flags coverage gaps, tracks convention compliance and capture rate trends, and identifies bus-factor risks (knowledge concentrated in one person).

--- a/commands/migration.md
+++ b/commands/migration.md
@@ -1,5 +1,0 @@
----
-description: Plan and execute knowledge graph updates during major refactoring
----
-
-Dispatch the `@sia-migration` agent. See [`agents/sia-migration.md`](../agents/sia-migration.md) — at a glance: plans and executes graph updates during major refactoring — renames entities, rewires edges, invalidates stale knowledge, and cleans graph data after an architecture change.

--- a/commands/playbooks.md
+++ b/commands/playbooks.md
@@ -1,5 +1,0 @@
----
-description: Load SIA task-specific playbooks for regression, feature, review, or orientation
----
-
-Run the `/sia-playbooks` skill. 

--- a/commands/pm-briefing.md
+++ b/commands/pm-briefing.md
@@ -1,5 +1,0 @@
----
-description: Generate plain-language project briefings for project managers
----
-
-Dispatch the `@sia-pm-briefing` agent. See [`agents/sia-pm-briefing.md`](../agents/sia-pm-briefing.md) — at a glance: generates plain-language project briefings for PMs — progress updates, decision summaries, risk areas, team activity. Works for both technical and non-technical PM audiences.

--- a/commands/pm-decision-log.md
+++ b/commands/pm-decision-log.md
@@ -1,5 +1,0 @@
----
-description: Generate chronological decision log with rationale and alternatives
----
-
-Run the `/sia-pm-decision-log` skill. 

--- a/commands/pm-risk-advisor.md
+++ b/commands/pm-risk-advisor.md
@@ -1,5 +1,0 @@
----
-description: Technical risk advisor for PMs — debt, fragile modules, dependency risks
----
-
-Dispatch the `@sia-pm-risk-advisor` agent. See [`agents/sia-pm-risk-advisor.md`](../agents/sia-pm-risk-advisor.md) — at a glance: surfaces technical debt, recurring bugs, fragile modules, and dependency risks from the graph and translates them into business-impact language for PM audiences.

--- a/commands/pm-risk-dashboard.md
+++ b/commands/pm-risk-dashboard.md
@@ -1,5 +1,0 @@
----
-description: Generate technical risk dashboard scored by impact
----
-
-Run the `/sia-pm-risk-dashboard` skill. 

--- a/commands/pm-sprint-summary.md
+++ b/commands/pm-sprint-summary.md
@@ -1,5 +1,0 @@
----
-description: Generate sprint summary in plain language for PMs
----
-
-Run the `/sia-pm-sprint-summary` skill. 

--- a/commands/prune.md
+++ b/commands/prune.md
@@ -1,5 +1,0 @@
----
-description: Remove archived entities from the knowledge graph
----
-
-Run the `/sia-prune` skill. 

--- a/commands/qa-analyst.md
+++ b/commands/qa-analyst.md
@@ -1,5 +1,0 @@
----
-description: QA intelligence — regression risks, coverage gaps, test recommendations
----
-
-Dispatch the `@sia-qa-analyst` agent. See [`agents/sia-qa-analyst.md`](../agents/sia-qa-analyst.md) — at a glance: QA intelligence agent — identifies regression risk areas, coverage gaps, recently changed modules, and produces test recommendations for QA and SDET teams.

--- a/commands/qa-coverage.md
+++ b/commands/qa-coverage.md
@@ -1,5 +1,0 @@
----
-description: Analyze test coverage gaps from the knowledge graph
----
-
-Run the `/sia-qa-coverage` skill. 

--- a/commands/qa-flaky.md
+++ b/commands/qa-flaky.md
@@ -1,5 +1,0 @@
----
-description: Track flaky test patterns and recurring failures
----
-
-Run the `/sia-qa-flaky` skill. 

--- a/commands/qa-regression-map.md
+++ b/commands/qa-regression-map.md
@@ -1,5 +1,0 @@
----
-description: Generate scored regression risk map (0-100) per module
----
-
-Dispatch the `@sia-qa-regression-map` agent. See [`agents/sia-qa-regression-map.md`](../agents/sia-qa-regression-map.md) — at a glance: produces a single ranked table with numeric risk ratings (0-100) per module by combining bug density, change velocity, and dependency fan-out. Optimised for test prioritisation decisions.

--- a/commands/qa-report.md
+++ b/commands/qa-report.md
@@ -1,5 +1,0 @@
----
-description: Generate QA-focused report — risky areas, test priorities
----
-
-Run the `/sia-qa-report` skill. 

--- a/commands/reindex.md
+++ b/commands/reindex.md
@@ -1,5 +1,0 @@
----
-description: Re-index repository code to update the knowledge graph
----
-
-Run the `/sia-reindex` skill. 

--- a/commands/review-respond.md
+++ b/commands/review-respond.md
@@ -1,5 +1,0 @@
----
-description: Respond to code review feedback with graph-backed evidence
----
-
-Run the `/sia-review-respond` skill. 

--- a/commands/search-debugger.md
+++ b/commands/search-debugger.md
@@ -1,5 +1,0 @@
----
-description: Diagnose why a `sia_search` returned nothing or the wrong results
----
-
-Dispatch the `@sia-search-debugger` agent. See [`agents/sia-search-debugger.md`](../agents/sia-search-debugger.md) — at a glance: inspects the query terms against the real graph, tries reformulations, and reports whether the graph is empty, the vocabulary is off, or the knowledge simply isn't captured.

--- a/commands/team.md
+++ b/commands/team.md
@@ -1,5 +1,0 @@
----
-description: Manage SIA team sync — join, leave, check status
----
-
-Run the `/sia-team` skill. 

--- a/commands/test-advisor.md
+++ b/commands/test-advisor.md
@@ -1,5 +1,0 @@
----
-description: Test strategy advice from past failures, coverage gaps, and edge cases
----
-
-Dispatch the `@sia-test-advisor` agent. See [`agents/sia-test-advisor.md`](../agents/sia-test-advisor.md) — at a glance: advises on test strategy using past test failures, known edge cases from Bug entities, coverage gaps, and project-specific test conventions from the graph.

--- a/commands/visualize-live.md
+++ b/commands/visualize-live.md
@@ -1,5 +1,0 @@
----
-description: Launch interactive browser-based knowledge graph visualizer
----
-
-Run the `/sia-visualize-live` skill. 


### PR DESCRIPTION
## Summary

Phase 7 deferred command-palette pruning because no principled rule distinguished a palette-worthy alias from clutter. This PR drafts that rule, applies it, and lands at **40 commands** (down from 74).

Every cut command's functionality remains reachable — skills as `/sia-<name>`, agents as `@sia-<name>`. Only the short-alias slash shim was removed. If the rule proves too aggressive, any cut is a one-file revert.

## Pruning rule (for debate)

**KEEP a command if ANY of:**

1. It takes arguments (`argument-hint:` in frontmatter) — the short alias carries ergonomic value that `/sia-<name>` cannot replicate without more typing per invocation.
2. It wraps an MCP tool directly (non-shim body that invokes a tool like `sia_at_time` or `sia_community`) — no corresponding `/sia-X` skill exists to absorb the command.
3. It is one of the five `/nous-*` cognitive-layer commands — CLAUDE.md's Nous Tool Contract references these by name as the canonical slash interface.
4. It is a high-frequency daily-workflow short alias where the short form provides real discoverability value — the curated set is `/setup`, `/install`, `/doctor`, `/tour`, `/stats`, `/status`, `/capture`, `/learn`, `/search`, `/debug`, `/plan`, `/test`, `/verify`, `/upgrade`, `/finish`, `/brainstorm`, `/execute`, `/execute-plan`, `/dispatch`, `/conflicts`, `/freshness`, `/digest`, `/workspace`, `/sync`, plus the agent-canonical entries `/code-reviewer`, `/pr-writer`, `/refactor`, `/regression`, `/security-audit`, `/knowledge-capture`, `/onboarding`, `/orientation`, `/explain`.

**CUT a command if ALL of:**

1. It is a 2-line shim with no `$ARGUMENTS` handling.
2. A `/sia-<name>` skill or `@sia-<name>` agent already autocompletes from the palette.
3. It is not in the daily-workflow curation list above.
4. It is not an MCP-direct or Nous-layer command.

**Why not the simpler "prefix rule"?** The starting heuristic — "cut any alias whose name is a prefix of the canonical `/sia-<name>`" — is too mechanical. It would cut `/search` and `/setup`, which are the highest-frequency entries a new user reaches for. The refined rule is explicit about which aliases get protected so the cut list is defensible rather than arbitrary. Open to sharpening rule 4's curation list on merge.

## Close calls (for future sharpening)

- `/freshness` was listed under "Direct MCP wrappers" in PLUGIN_USAGE but is actually a pure `/sia-freshness` skill shim. Kept because it's on the daily-ops list (weekly health check); recategorised to the shim table. Arguably a cut if we tighten rule 4.
- `/capture` (skill shim, no args) vs `/knowledge-capture` (agent dispatch). Kept both — they are genuinely different interaction models (quick inline capture vs systematic session-level extraction), but a reviewer could argue one absorbs the other.
- `/tour` (graph tour skill) vs `/onboarding` (multi-topic session agent). Kept both for the same reason. Close call.
- `/explain` (agent) vs `/orientation` (agent). Two different slash entries pointing at two different agents; both kept under rule 4.
- `/brainstorm`, `/dispatch`, `/execute`, `/execute-plan` — borderline "is this daily?". Kept to stay conservative; cut candidates for next review.

## Verification

- `bash scripts/validate-plugin.sh` — OK (9 checks passed)
- `bash scripts/count-plugin-components.sh` — Commands: 40 (target hit)
- `bash scripts/generate-plugin-usage.sh --verify` — OK
- `bunx tsc --noEmit` — clean (exit 0)
- `bunx @biomejs/biome check .` — clean (exit 0; no src/ touched)
- `bun run test` — 2024/2025 pass. The single failing test (`isWorktree` → expected false, got true) is environmental: we're running inside a git worktree, so `isWorktree()` correctly returns `true`. No source or test file was touched in this branch; the failure reproduces on `main` under the same worktree conditions.

## Cut list (34 commands)

<details>
<summary>Skill shim aliases (18)</summary>

- `/compare` → `/sia-compare`
- `/export` → `/sia-export-knowledge`
- `/export-import` → `/sia-export-import`
- `/history` → `/sia-history`
- `/impact` → `/sia-impact`
- `/index` → `/sia-index`
- `/playbooks` → `/sia-playbooks`
- `/pm-decision-log` → `/sia-pm-decision-log`
- `/pm-risk-dashboard` → `/sia-pm-risk-dashboard`
- `/pm-sprint-summary` → `/sia-pm-sprint-summary`
- `/prune` → `/sia-prune`
- `/qa-coverage` → `/sia-qa-coverage`
- `/qa-flaky` → `/sia-qa-flaky`
- `/qa-report` → `/sia-qa-report`
- `/reindex` → `/sia-reindex`
- `/review-respond` → `/sia-review-respond`
- `/team` → `/sia-team`
- `/visualize-live` → `/sia-visualize-live`

</details>

<details>
<summary>Agent delegation shims (16)</summary>

- `/changelog-writer` → `@sia-changelog-writer`
- `/conflict-resolver` → `@sia-conflict-resolver`
- `/convention-enforcer` → `@sia-convention-enforcer`
- `/decision-reviewer` → `@sia-decision-reviewer`
- `/dependency-tracker` → `@sia-dependency-tracker`
- `/doc-writer` → `@sia-doc-writer`
- `/feature` → `@sia-feature`
- `/lead-architecture-advisor` → `@sia-lead-architecture-advisor`
- `/lead-team-health` → `@sia-lead-team-health`
- `/migration` → `@sia-migration`
- `/pm-briefing` → `@sia-pm-briefing`
- `/pm-risk-advisor` → `@sia-pm-risk-advisor`
- `/qa-analyst` → `@sia-qa-analyst`
- `/qa-regression-map` → `@sia-qa-regression-map`
- `/search-debugger` → `@sia-search-debugger`
- `/test-advisor` → `@sia-test-advisor`

</details>

## Test plan

- [ ] Install the branch locally and confirm palette shows 40 commands
- [ ] Confirm every cut command's canonical entry is still reachable (`/sia-<name>` or `@sia-<name>`)
- [ ] Debate rule 4's curation list on merge — particularly the close-calls section