### PR TITLE
Phase A1: extract snapshot MCP tools; v1.2.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.2.3"
+		"version": "1.2.4"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.2.3",
+			"version": "1.2.4",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.2.3"
+	"version": "1.2.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.2.4] — 2026-04-22
+
+### Changed
+
+- Extract 3 inline snapshot MCP handlers to dedicated
+  `src/mcp/tools/sia-snapshot-*.ts` files (no behaviour change; matches
+  pattern of other tools). Unblocks Phase A2 next_steps helper rollout.
+
 ## [1.2.3] - 2026-04-21
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rkarim08/sia",
-	"version": "1.1.0",
+	"version": "1.2.4",
 	"description": "Persistent graph memory for AI coding agents",
 	"type": "module",
 	"license": "Apache-2.0",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -37,6 +37,9 @@ import { handleSiaIndex } from "@/mcp/tools/sia-index";
 import { handleSiaModels, SiaModelsInput } from "@/mcp/tools/sia-models";
 import { handleSiaNote } from "@/mcp/tools/sia-note";
 import { handleSiaSearch } from "@/mcp/tools/sia-search";
+import { handleSiaSnapshotList } from "@/mcp/tools/sia-snapshot-list";
+import { handleSiaSnapshotPrune } from "@/mcp/tools/sia-snapshot-prune";
+import { handleSiaSnapshotRestore } from "@/mcp/tools/sia-snapshot-restore";
 import { handleSiaStats } from "@/mcp/tools/sia-stats";
 import { handleSiaSyncStatus } from "@/mcp/tools/sia-sync-status";
 import { handleSiaUpgrade } from "@/mcp/tools/sia-upgrade";
@@ -963,17 +966,7 @@ export function createMcpServer(deps?: McpServerDeps): McpServer {
 			if (deps) {
 				return safeToolCall(
 					"sia_snapshot_list",
-					async () => {
-						const { listBranchSnapshots } = await import("@/graph/snapshots");
-						const snapshots = await listBranchSnapshots(deps.graphDb);
-						return snapshots.map((s) => ({
-							branch_name: s.branch_name,
-							commit_hash: s.commit_hash,
-							node_count: s.node_count,
-							edge_count: s.edge_count,
-							updated_at: s.updated_at,
-						}));
-					},
+					() => handleSiaSnapshotList(deps.graphDb),
 					maxChars,
 				);
 			}
@@ -1001,11 +994,7 @@ export function createMcpServer(deps?: McpServerDeps): McpServer {
 			if (deps) {
 				return safeToolCall(
 					"sia_snapshot_restore",
-					async () => {
-						const { restoreBranchSnapshot } = await import("@/graph/snapshots");
-						const restored = await restoreBranchSnapshot(deps.graphDb, args.branch_name);
-						return { restored, branch_name: args.branch_name };
-					},
+					() => handleSiaSnapshotRestore(deps.graphDb, args),
 					maxChars,
 				);
 			}
@@ -1033,11 +1022,7 @@ export function createMcpServer(deps?: McpServerDeps): McpServer {
 			if (deps) {
 				return safeToolCall(
 					"sia_snapshot_prune",
-					async () => {
-						const { pruneBranchSnapshots } = await import("@/graph/snapshots");
-						const pruned = await pruneBranchSnapshots(deps.graphDb, args.branch_names);
-						return { pruned, branch_names: args.branch_names };
-					},
+					() => handleSiaSnapshotPrune(deps.graphDb, args),
 					maxChars,
 				);
 			}

--- a/src/mcp/tools/sia-snapshot-list.ts
+++ b/src/mcp/tools/sia-snapshot-list.ts
@@ -1,0 +1,58 @@
+// Module: sia-snapshot-list — Handler for the sia_snapshot_list MCP tool
+
+import type { SiaDb } from "@/graph/db-interface";
+import { listBranchSnapshots } from "@/graph/snapshots";
+
+// ---------------------------------------------------------------------------
+// SiaSnapshotListRow — one row per branch snapshot
+// ---------------------------------------------------------------------------
+
+export interface SiaSnapshotListRow {
+	branch_name: string;
+	commit_hash: string;
+	node_count: number;
+	edge_count: number;
+	updated_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// SiaSnapshotListResult — MCP response shape
+// ---------------------------------------------------------------------------
+
+export interface SiaSnapshotListResult {
+	snapshots: SiaSnapshotListRow[];
+	error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// handleSiaSnapshotList
+// ---------------------------------------------------------------------------
+
+/**
+ * Return all branch-keyed graph snapshots, newest first (ordering is
+ * delegated to `listBranchSnapshots`). The `snapshot_data` blob and
+ * `created_at` / `id` columns are intentionally omitted from the MCP
+ * response — callers only need the summary columns.
+ *
+ * On failure the handler does not propagate the error; it matches the
+ * `sia-stats` convention and returns `{ snapshots: [], error: string }`.
+ */
+export async function handleSiaSnapshotList(db: SiaDb): Promise<SiaSnapshotListResult> {
+	try {
+		const snapshots = await listBranchSnapshots(db);
+		return {
+			snapshots: snapshots.map((s) => ({
+				branch_name: s.branch_name,
+				commit_hash: s.commit_hash,
+				node_count: s.node_count,
+				edge_count: s.edge_count,
+				updated_at: s.updated_at,
+			})),
+		};
+	} catch (err) {
+		return {
+			snapshots: [],
+			error: `Snapshot list query failed: ${(err as Error).message}`,
+		};
+	}
+}

--- a/src/mcp/tools/sia-snapshot-prune.ts
+++ b/src/mcp/tools/sia-snapshot-prune.ts
@@ -1,0 +1,37 @@
+// Module: sia-snapshot-prune — Handler for the sia_snapshot_prune MCP tool
+
+import type { z } from "zod";
+import type { SiaDb } from "@/graph/db-interface";
+import { pruneBranchSnapshots } from "@/graph/snapshots";
+import type { SiaSnapshotPruneInput } from "@/mcp/server";
+import { validateBranchNames } from "@/mcp/tools/sia-snapshot-shared";
+
+// ---------------------------------------------------------------------------
+// SiaSnapshotPruneResult
+// ---------------------------------------------------------------------------
+
+export interface SiaSnapshotPruneResult {
+	pruned: number;
+	branch_names: string[];
+}
+
+// ---------------------------------------------------------------------------
+// handleSiaSnapshotPrune
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove branch-keyed snapshots for the named branches.
+ *
+ * Validates every branch name at the MCP boundary. Returns the number of
+ * rows actually deleted plus the (validated) input list, preserving the
+ * response shape used by the inline handler previously embedded in
+ * `src/mcp/server.ts`.
+ */
+export async function handleSiaSnapshotPrune(
+	db: SiaDb,
+	input: z.infer<typeof SiaSnapshotPruneInput>,
+): Promise<SiaSnapshotPruneResult> {
+	const branchNames = validateBranchNames(input.branch_names);
+	const pruned = await pruneBranchSnapshots(db, branchNames);
+	return { pruned, branch_names: branchNames };
+}

--- a/src/mcp/tools/sia-snapshot-restore.ts
+++ b/src/mcp/tools/sia-snapshot-restore.ts
@@ -1,0 +1,37 @@
+// Module: sia-snapshot-restore — Handler for the sia_snapshot_restore MCP tool
+
+import type { z } from "zod";
+import type { SiaDb } from "@/graph/db-interface";
+import { restoreBranchSnapshot } from "@/graph/snapshots";
+import type { SiaSnapshotRestoreInput } from "@/mcp/server";
+import { validateBranchName } from "@/mcp/tools/sia-snapshot-shared";
+
+// ---------------------------------------------------------------------------
+// SiaSnapshotRestoreResult
+// ---------------------------------------------------------------------------
+
+export interface SiaSnapshotRestoreResult {
+	restored: boolean;
+	branch_name: string;
+}
+
+// ---------------------------------------------------------------------------
+// handleSiaSnapshotRestore
+// ---------------------------------------------------------------------------
+
+/**
+ * Restore the active graph from a branch-keyed snapshot.
+ *
+ * Validates the branch name at the MCP boundary so an empty / non-string
+ * input produces a clear error rather than a silent miss against the
+ * branch_snapshots table. Returns `{ restored: false }` when the branch
+ * exists as input but has no stored snapshot.
+ */
+export async function handleSiaSnapshotRestore(
+	db: SiaDb,
+	input: z.infer<typeof SiaSnapshotRestoreInput>,
+): Promise<SiaSnapshotRestoreResult> {
+	const branchName = validateBranchName(input.branch_name);
+	const restored = await restoreBranchSnapshot(db, branchName);
+	return { restored, branch_name: branchName };
+}

--- a/src/mcp/tools/sia-snapshot-shared.ts
+++ b/src/mcp/tools/sia-snapshot-shared.ts
@@ -1,0 +1,42 @@
+// Module: sia-snapshot-shared — Shared helpers for branch-keyed snapshot MCP handlers
+//
+// Currently exposes a single validator used by sia_snapshot_restore and
+// sia_snapshot_prune to reject empty / whitespace-only branch names before
+// they reach the graph layer. Keeping the validator here lets the three
+// snapshot tool modules share the same error surface.
+
+/**
+ * Validate a branch name for the snapshot MCP handlers.
+ *
+ * The graph layer (see `src/graph/snapshots.ts`) does not enforce any
+ * structural constraints on branch names, but at the MCP boundary we reject
+ * obvious garbage (empty or whitespace-only strings) so callers get a clear
+ * error instead of a silent miss. Throws `Error` on invalid input.
+ *
+ * Validation is trim-aware (so `"   "` is rejected), but the returned string
+ * is the caller's original input — not the trimmed version. This preserves
+ * the response `branch_name` field verbatim; the DB call naturally returns
+ * `restored: false` for any padded name that does not match.
+ */
+export function validateBranchName(branchName: unknown): string {
+	if (typeof branchName !== "string") {
+		throw new Error("Invalid snapshot name: branch_name must be a string");
+	}
+	if (branchName.trim().length === 0) {
+		throw new Error("Invalid snapshot name: branch_name must be a non-empty string");
+	}
+	return branchName;
+}
+
+/**
+ * Validate a list of branch names for `sia_snapshot_prune`. Every entry must
+ * satisfy `validateBranchName`; duplicates are preserved (the graph layer
+ * handles them). Throws `Error` if any entry is invalid. Returns the
+ * original entries unchanged (see `validateBranchName` for rationale).
+ */
+export function validateBranchNames(branchNames: unknown): string[] {
+	if (!Array.isArray(branchNames)) {
+		throw new Error("Invalid snapshot name: branch_names must be an array");
+	}
+	return branchNames.map((name) => validateBranchName(name));
+}

--- a/tests/unit/mcp/tools/sia-snapshot-list.test.ts
+++ b/tests/unit/mcp/tools/sia-snapshot-list.test.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SiaDb } from "@/graph/db-interface";
+import { openGraphDb } from "@/graph/semantic-db";
+import * as snapshotsModule from "@/graph/snapshots";
+import { createBranchSnapshot } from "@/graph/snapshots";
+import { handleSiaSnapshotList } from "@/mcp/tools/sia-snapshot-list";
+
+describe("sia_snapshot_list tool", () => {
+	let tmpDir: string;
+	let db: SiaDb | undefined;
+
+	function makeTmp(): string {
+		const dir = join(tmpdir(), `sia-test-${randomUUID()}`);
+		mkdirSync(dir, { recursive: true });
+		return dir;
+	}
+
+	afterEach(async () => {
+		if (db) {
+			await db.close();
+			db = undefined;
+		}
+		if (tmpDir) {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+		vi.restoreAllMocks();
+	});
+
+	// ---------------------------------------------------------------
+	// Empty path
+	// ---------------------------------------------------------------
+
+	it("returns an empty snapshots array when no branch snapshots exist", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		const result = await handleSiaSnapshotList(db);
+
+		expect(result).toEqual({ snapshots: [] });
+		expect(result.error).toBeUndefined();
+	});
+
+	// ---------------------------------------------------------------
+	// Normal path
+	// ---------------------------------------------------------------
+
+	it("returns summary rows for each stored branch snapshot", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		await createBranchSnapshot(db, "feature/alpha", "abc123");
+		await createBranchSnapshot(db, "feature/beta", "def456");
+
+		const result = await handleSiaSnapshotList(db);
+
+		expect(result.error).toBeUndefined();
+		expect(result.snapshots).toHaveLength(2);
+		const names = result.snapshots.map((r) => r.branch_name).sort();
+		expect(names).toEqual(["feature/alpha", "feature/beta"]);
+
+		// Every row exposes the documented summary columns and nothing else.
+		for (const row of result.snapshots) {
+			expect(row).toEqual({
+				branch_name: expect.any(String),
+				commit_hash: expect.any(String),
+				node_count: expect.any(Number),
+				edge_count: expect.any(Number),
+				updated_at: expect.any(Number),
+			});
+		}
+	});
+
+	// ---------------------------------------------------------------
+	// snapshot_data is not leaked to MCP callers
+	// ---------------------------------------------------------------
+
+	it("does not expose the snapshot_data blob in the MCP response", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		await createBranchSnapshot(db, "main", "hash-main");
+
+		const result = await handleSiaSnapshotList(db);
+
+		expect(result.snapshots).toHaveLength(1);
+		expect(Object.keys(result.snapshots[0])).not.toContain("snapshot_data");
+		expect(Object.keys(result.snapshots[0])).not.toContain("id");
+		expect(Object.keys(result.snapshots[0])).not.toContain("created_at");
+	});
+
+	// ---------------------------------------------------------------
+	// Error path — listBranchSnapshots throws
+	// ---------------------------------------------------------------
+
+	it("returns the documented error shape when the underlying query throws", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		const spy = vi.spyOn(snapshotsModule, "listBranchSnapshots").mockImplementation(async () => {
+			throw new Error("boom from graph layer");
+		});
+
+		// Should not propagate — handler swallows and returns { snapshots: [], error }.
+		const result = await handleSiaSnapshotList(db);
+
+		expect(spy).toHaveBeenCalledOnce();
+		expect(result.snapshots).toEqual([]);
+		expect(result.error).toMatch(/Snapshot list query failed/);
+		expect(result.error).toMatch(/boom from graph layer/);
+	});
+});

--- a/tests/unit/mcp/tools/sia-snapshot-prune.test.ts
+++ b/tests/unit/mcp/tools/sia-snapshot-prune.test.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SiaDb } from "@/graph/db-interface";
+import { openGraphDb } from "@/graph/semantic-db";
+import { createBranchSnapshot } from "@/graph/snapshots";
+import { handleSiaSnapshotPrune } from "@/mcp/tools/sia-snapshot-prune";
+
+describe("sia_snapshot_prune tool", () => {
+	let tmpDir: string;
+	let db: SiaDb | undefined;
+
+	function makeTmp(): string {
+		const dir = join(tmpdir(), `sia-test-${randomUUID()}`);
+		mkdirSync(dir, { recursive: true });
+		return dir;
+	}
+
+	afterEach(async () => {
+		if (db) {
+			await db.close();
+			db = undefined;
+		}
+		if (tmpDir) {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	// ---------------------------------------------------------------
+	// Normal path — prunes existing branches
+	// ---------------------------------------------------------------
+
+	it("prunes snapshots for the named branches and returns the deleted count", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		await createBranchSnapshot(db, "feature/one", "hash-1");
+		await createBranchSnapshot(db, "feature/two", "hash-2");
+		await createBranchSnapshot(db, "feature/three", "hash-3");
+
+		const result = await handleSiaSnapshotPrune(db, {
+			branch_names: ["feature/one", "feature/two"],
+		});
+
+		expect(result).toEqual({
+			pruned: 2,
+			branch_names: ["feature/one", "feature/two"],
+		});
+
+		// feature/three is untouched.
+		const { rows } = await db.execute("SELECT branch_name FROM branch_snapshots");
+		expect(rows.map((r) => r.branch_name)).toEqual(["feature/three"]);
+	});
+
+	// ---------------------------------------------------------------
+	// Empty path — no matching branches
+	// ---------------------------------------------------------------
+
+	it("returns pruned: 0 when none of the named branches exist", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		const result = await handleSiaSnapshotPrune(db, {
+			branch_names: ["ghost-branch-a", "ghost-branch-b"],
+		});
+
+		expect(result).toEqual({
+			pruned: 0,
+			branch_names: ["ghost-branch-a", "ghost-branch-b"],
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// Empty input list is an allowed no-op (matches graph layer)
+	// ---------------------------------------------------------------
+
+	it("returns pruned: 0 for an empty branch_names input", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		await createBranchSnapshot(db, "stays", "hash-s");
+
+		const result = await handleSiaSnapshotPrune(db, { branch_names: [] });
+
+		expect(result).toEqual({ pruned: 0, branch_names: [] });
+
+		const { rows } = await db.execute("SELECT COUNT(*) AS cnt FROM branch_snapshots");
+		expect(Number(rows[0].cnt)).toBe(1);
+	});
+
+	// ---------------------------------------------------------------
+	// Error path — invalid snapshot name in the list
+	// ---------------------------------------------------------------
+
+	it("throws if any branch name is empty / whitespace-only", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		await createBranchSnapshot(db, "feature/live", "hash-live");
+
+		await expect(
+			handleSiaSnapshotPrune(db, { branch_names: ["feature/live", ""] }),
+		).rejects.toThrow(/Invalid snapshot name/);
+
+		// No rows were deleted — validation runs before the DB touch.
+		const { rows } = await db.execute("SELECT COUNT(*) AS cnt FROM branch_snapshots");
+		expect(Number(rows[0].cnt)).toBe(1);
+	});
+});

--- a/tests/unit/mcp/tools/sia-snapshot-restore.test.ts
+++ b/tests/unit/mcp/tools/sia-snapshot-restore.test.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SiaDb } from "@/graph/db-interface";
+import { insertEntity } from "@/graph/entities";
+import { openGraphDb } from "@/graph/semantic-db";
+import { createBranchSnapshot } from "@/graph/snapshots";
+import { handleSiaSnapshotRestore } from "@/mcp/tools/sia-snapshot-restore";
+
+describe("sia_snapshot_restore tool", () => {
+	let tmpDir: string;
+	let db: SiaDb | undefined;
+
+	function makeTmp(): string {
+		const dir = join(tmpdir(), `sia-test-${randomUUID()}`);
+		mkdirSync(dir, { recursive: true });
+		return dir;
+	}
+
+	afterEach(async () => {
+		if (db) {
+			await db.close();
+			db = undefined;
+		}
+		if (tmpDir) {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	// ---------------------------------------------------------------
+	// Normal path — restores a previously stored snapshot
+	// ---------------------------------------------------------------
+
+	it("restores a stored branch snapshot and reports restored: true", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		await insertEntity(db, {
+			type: "Concept",
+			name: "Pre-snapshot entity",
+			content: "Exists at snapshot time",
+			summary: "seed",
+			created_by: "dev-1",
+		});
+
+		await createBranchSnapshot(db, "feature/restore", "commit-1");
+
+		const result = await handleSiaSnapshotRestore(db, { branch_name: "feature/restore" });
+
+		expect(result).toEqual({ restored: true, branch_name: "feature/restore" });
+	});
+
+	// ---------------------------------------------------------------
+	// Empty path — branch with no stored snapshot
+	// ---------------------------------------------------------------
+
+	it("reports restored: false when the branch has no stored snapshot", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		const result = await handleSiaSnapshotRestore(db, { branch_name: "never-snapshotted" });
+
+		expect(result).toEqual({ restored: false, branch_name: "never-snapshotted" });
+	});
+
+	// ---------------------------------------------------------------
+	// Error path — invalid snapshot name
+	// ---------------------------------------------------------------
+
+	it("throws on an empty / whitespace-only branch name", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		await expect(handleSiaSnapshotRestore(db, { branch_name: "" })).rejects.toThrow(
+			/Invalid snapshot name/,
+		);
+		await expect(handleSiaSnapshotRestore(db, { branch_name: "   " })).rejects.toThrow(
+			/Invalid snapshot name/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Move `sia_snapshot_{list,restore,prune}` from inline handlers in `src/mcp/server.ts:966-1054` to dedicated `src/mcp/tools/sia-snapshot-*.ts` files, matching the pattern used by other MCP tools.
- Shared validation helper in `sia-snapshot-shared.ts`. `TOOL_NAMES`, arg-schemas, and response shapes unchanged.
- `handleSiaSnapshotList` returns `{ snapshots, error? }` on failure, matching `sia-stats.ts` convention.
- `validateBranchName` validates (throws on empty-trimmed input) but returns the caller's original string — preserves `branch_name` response-field identity under "pure refactor" contract.
- 10 new tests covering normal/empty/error paths.

Unblocks Phase A2 (next_steps helper rollout on 19 tools).

Source plan: [docs/superpowers/plans/2026-04-21-roadmap-execution.md](../blob/main/docs/superpowers/plans/2026-04-21-roadmap-execution.md) (gitignored).

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean (on src/tests; biome.json ignores .claude/)
- [x] \`bun run test\` — 2035/2036 pass; only pre-existing \`git-utils > isWorktree\` fails when running inside a worktree
- [x] \`bash scripts/validate-plugin.sh\` — 9/9 OK
- [x] \`bash scripts/count-plugin-components.sh\` — 29 MCP tools unchanged