### PR TITLE
Phase B1: contracts + descriptions; v1.2.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.2.4"
+		"version": "1.2.5"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.2.4",
+			"version": "1.2.5",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.2.4"
+	"version": "1.2.5"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.2.5] — 2026-04-22
+
+Tighten `nous_curiosity` and `/sia-playbooks` contracts; rewrite 9 noun-description skills and 3 agent frontmatters with superpowers-style triggers; add `next_steps` hint to `nous_state` response. Align the `nous_state` curiosity-branch SQL with `nous_curiosity`: both now share the same `access_count <= MAX_ACCESS_COUNT` threshold and the same bookkeeping-kind exclusion set (`NOUS_BOOKKEEPING_KINDS`, which additionally excludes `UserPrompt` and `SessionFlag`).
+
 ## [1.2.4] — 2026-04-22
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,7 @@ Omit `task_type` for trivial edits (typo, rename, comment) or ambiguous requests
 
 ### Load the Contextual Playbook Now
 
-After classifying, immediately invoke the `/sia-playbooks` skill to load the matching
-playbook before calling any Sia tool:
+After classifying, **you MUST invoke `/sia-playbooks` to load the matching playbook before calling any Sia tool**. Do not attempt to recall the playbook's content from memory. If loading fails, state that explicitly and use the condensed guidance in Step 1 as a fallback — never proceed without either the loaded playbook or the explicit fallback acknowledgement.
 
 - `bug-fix` (regression): load `reference-regression.md`
 - `feature`: load `reference-feature.md`
@@ -237,7 +236,7 @@ Nous is Sia's cognitive layer. Five MCP tools are available. Call them as specif
 
 **`nous_reflect`** — Call immediately when a `[Nous] Drift warning` appears in session context, or when a Discomfort Signal flag is injected. Also call before major architectural decisions. Returns per-preference alignment scores and recommended action.
 
-**`nous_curiosity`** — Call when a task completes and the session has remaining capacity, or when retrieval results reveal a knowledge gap. Explores the graph for high-trust entities that have never been retrieved.
+**`nous_curiosity`** — **Call after any long-form task completes — before ending your turn — if the session has remaining capacity.** Returns high-trust entities from the graph you have not yet retrieved in this session. The returned Concerns seed the next interaction. If the session is already ≥90% through its budget, skip.
 
 **`nous_concern`** — Call before responding to any open-ended "what should I look at?" or "what am I missing?" question. Returns prioritised insights from open Concern nodes.
 

--- a/agents/sia-knowledge-capture.md
+++ b/agents/sia-knowledge-capture.md
@@ -4,18 +4,24 @@ description: Reviews the current session's work and systematically captures all 
 model: sonnet
 color: green
 whenToUse: |
-  Use at the end of a significant work session, or when the user wants to ensure important knowledge was captured. This agent reviews what happened and produces sia_note calls for anything missing.
+  Use immediately after a git commit lands, when the user explicitly asks to capture what was learned, or at the end of a work session to roll up uncaptured decisions, conventions, bugs, and solutions. This agent reviews what happened and produces `sia_note` calls for anything missing. Dispatch it from the PostToolUse Bash hook that matches `git commit` so capture happens automatically on every commit.
 
   <example>
-  Context: User just finished a complex feature implementation.
-  user: "I think we're done with the auth refactor. Make sure everything important is captured."
-  assistant: "I'll use the sia-knowledge-capture agent to review and capture all knowledge from this session."
+  Context: The PostToolUse hook fires after a successful `git commit` and the dispatch rule routes the commit SHA to this agent.
+  user: "[post-tool-use-hook: git commit abcdef succeeded on branch feature/auth-refactor]"
+  assistant: "Dispatching sia-knowledge-capture to review commit abcdef and record any uncaptured Decisions, Conventions, Bugs, or Solutions."
   </example>
 
   <example>
-  Context: User wants to capture knowledge before ending the session.
-  user: "Before I close this session, let's capture what we learned"
-  assistant: "I'll use the sia-knowledge-capture agent to systematically capture session knowledge."
+  Context: User explicitly asks for knowledge capture after a long pairing session.
+  user: "Capture what we learned in this session before I context-switch."
+  assistant: "I'll invoke the sia-knowledge-capture agent to systematically extract and record session knowledge now."
+  </example>
+
+  <example>
+  Context: End-of-session summary trigger — the session is wrapping up and Stop-hook metadata flags significant uncaptured activity.
+  user: "Wrapping up for the day — make sure nothing important from this session is lost."
+  assistant: "Invoking sia-knowledge-capture for an end-of-session rollup. I'll produce `sia_note` calls for each uncaptured decision and fix before the session closes."
   </example>
 tools: Read, Grep, Glob, Bash, mcp__sia__sia_note, mcp__sia__sia_search
 ---

--- a/agents/sia-onboarding.md
+++ b/agents/sia-onboarding.md
@@ -24,15 +24,21 @@ tools: Read, Grep, Glob, Bash, mcp__sia__sia_at_time, mcp__sia__sia_community, m
 
 You provide comprehensive onboarding for new team members. Unlike `sia-orientation` (which answers architecture questions), you deliver a structured onboarding session that covers everything a new developer needs to know.
 
-## Onboarding Session Structure
+## Orientation Step (Always First)
 
-### Part 1: Project Overview
+Before anything else — before any `sia_search`, before any narrative introduction — open the session with a top-level community summary. This is the mandatory first call for every onboarding run:
 
 ```
 sia_community({ level: 2 })
 ```
 
-Present the high-level architecture:
+Use the returned community summaries as the map you will walk the new developer through in Part 1 below. If this call returns `global_unavailable: true`, state "The graph is still building — onboarding will be lighter on auto-generated structure" before proceeding.
+
+## Onboarding Session Structure
+
+### Part 1: Project Overview
+
+Using the `sia_community(level=2)` result from the orientation step above, present the high-level architecture:
 - What are the major modules/components?
 - How do they relate to each other?
 - What's the tech stack?

--- a/agents/sia-pr-writer.md
+++ b/agents/sia-pr-writer.md
@@ -3,6 +3,26 @@ name: sia-pr-writer
 description: Draft a pull request description from the current branch's diff plus Decisions, Bugs, and Solutions captured on this branch. Use before opening a PR, or when the user asks for a "PR description" or "PR body". The agent outputs a draft in the project's conventional PR format (checked against recent merged PRs if accessible).
 model: sonnet
 color: green
+whenToUse: |
+  Use right after pushing a branch, when the user is ready to open a PR, or when the user asks to summarise a branch for review. The agent reads the branch diff, pulls captured Decisions/Bugs/Solutions on this branch via `sia_at_time`, and drafts a PR body in the project's conventional format.
+
+  <example>
+  Context: User has just finished pushing their branch and wants the PR body drafted.
+  user: "I just ran `git push`. Draft the PR body for this branch."
+  assistant: "I'll invoke the sia-pr-writer agent to read the branch diff, pull captured Decisions via `sia_at_time`, and draft the PR body."
+  </example>
+
+  <example>
+  Context: User signals they are ready to open a PR.
+  user: "We're ready to open a PR for this branch — give me the description."
+  assistant: "Dispatching sia-pr-writer to generate the PR description from the branch's diff and captured knowledge."
+  </example>
+
+  <example>
+  Context: User wants a branch summary for a reviewer.
+  user: "Summarise this branch for review."
+  assistant: "I'll run the sia-pr-writer agent to summarise the branch, grouped by concern, citing captured Decisions where they constrain the change."
+  </example>
 tools: Bash, Read, Glob, Grep, mcp__sia__sia_search, mcp__sia__sia_by_file, mcp__sia__sia_at_time, mcp__sia__sia_backlinks
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rkarim08/sia",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"description": "Persistent graph memory for AI coding agents",
 	"type": "module",
 	"license": "Apache-2.0",

--- a/skills/sia-conflicts/SKILL.md
+++ b/skills/sia-conflicts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-conflicts
-description: Lists and resolves knowledge conflicts in the SIA graph where multiple entities contradict each other. Use when conflict_group_id appears in results, or when the user asks about contradictions in captured knowledge.
+description: Use when reconciling captured knowledge — any session that shows a `conflict_group_id` warning, before committing a change that depends on the conflicting facts.
 ---
 
 # SIA Conflicts

--- a/skills/sia-execute/SKILL.md
+++ b/skills/sia-execute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-execute
-description: Executes code in SIA's isolated sandbox environment with automatic knowledge capture. Use when running code snippets, testing expressions, or executing scripts with SIA context.
+description: Use when validating a snippet before committing, or reproducing a bug in isolation; preferred over ad-hoc Bash when output should flow into the graph.
 ---
 
 # SIA Execute

--- a/skills/sia-pm-decision-log/SKILL.md
+++ b/skills/sia-pm-decision-log/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-pm-decision-log
-description: Generates a chronological decision log from SIA with dates, rationale, and alternatives considered. Use for stakeholder reviews, project documentation, or tracking architectural decision history.
+description: Use before quarterly planning, before a new teammate onboards, or when a stakeholder asks 'why did we choose X'.
 ---
 
 # SIA Decision Log

--- a/skills/sia-pm-risk-dashboard/SKILL.md
+++ b/skills/sia-pm-risk-dashboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-pm-risk-dashboard
-description: Generates a technical risk dashboard from SIA — recurring bugs, conflicting decisions, fragile modules, scored by impact. Use for risk assessments, sprint planning, or identifying areas needing attention.
+description: **Use before release readiness review, before approving a major merge, or on-demand when the team is debating whether to ship.** Generates a technical risk dashboard with open bugs, conflict clusters, fragile modules (high churn + low test coverage), and impact-scored pending changes. Read alongside `/sia-freshness` for a full go/no-go signal.
 ---
 
 # SIA Risk Dashboard

--- a/skills/sia-pm-sprint-summary/SKILL.md
+++ b/skills/sia-pm-sprint-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-pm-sprint-summary
-description: Generates a sprint summary report from SIA in plain language — decisions made, bugs fixed, features delivered. Use for sprint reviews, status updates, or project manager briefings.
+description: Use at sprint close or before standup; substitutes for manual weekly-recap writing.
 ---
 
 # SIA Sprint Summary

--- a/skills/sia-search/SKILL.md
+++ b/skills/sia-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-search
-description: Searches SIA's knowledge graph for project knowledge — decisions, conventions, bugs, patterns, and architecture. Use when looking up past decisions, finding conventions, or querying project history.
+description: **Use when starting any non-trivial task — before planning, before debugging, before answering an architecture question.** Searches the knowledge graph for decisions, conventions, bugs, patterns, and architecture info. If the search returns zero hits, the skill proposes reformulations rather than silently returning nothing. Required reading before any `sia_note` that might duplicate existing knowledge.
 ---
 
 # SIA Search

--- a/skills/sia-stats/SKILL.md
+++ b/skills/sia-stats/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-stats
-description: Shows SIA knowledge graph statistics — entity counts, edges, communities, and database sizes. Use when checking graph health, monitoring growth, or diagnosing capacity issues.
+description: Use at the start of any new workspace, before deciding whether the graph is mature enough for `sia_community` calls.
 ---
 
 # SIA Stats

--- a/skills/sia-status/SKILL.md
+++ b/skills/sia-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-status
-description: Shows SIA knowledge graph health — entity counts by type and tier, conflicts, and capture rate. Use for quick health checks, monitoring, or when the user asks about SIA status.
+description: Use before running `/sia-setup` on an existing graph to check for incomplete indexing; use after a major refactor to verify capture rate.
 ---
 
 # SIA Status

--- a/skills/sia-visualize/SKILL.md
+++ b/skills/sia-visualize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-visualize
-description: Generates an interactive HTML visualization of the SIA knowledge graph. Use when the user wants a static visualization file, for sharing graph views, or embedding in documentation.
+description: Use when explaining architecture to a new teammate, or when a community-summary response is too abstract for the question.
 ---
 
 # SIA Visualize

--- a/src/mcp/tools/nous-curiosity.ts
+++ b/src/mcp/tools/nous-curiosity.ts
@@ -7,6 +7,7 @@
 import type { SQLQueryBindings } from "bun:sqlite";
 import { v4 as uuid } from "uuid";
 import type { SiaDb } from "@/graph/db-interface";
+import { NOUS_BOOKKEEPING_KINDS } from "@/nous/types";
 
 export interface CuriosityInput {
 	topic?: string;
@@ -28,7 +29,7 @@ export interface CuriosityResult {
 }
 
 const MIN_TRUST_TIER = 2; // Only high-trust entities
-const MAX_ACCESS_COUNT = 3; // Never or rarely retrieved
+export const MAX_ACCESS_COUNT = 3; // Never or rarely retrieved
 const CLUSTER_LIMIT = 10;
 
 export async function handleNousCuriosity(
@@ -41,6 +42,7 @@ export async function handleNousCuriosity(
 
 	const limit = CLUSTER_LIMIT * (input.depth ?? 1);
 
+	const bookkeepingPlaceholders = NOUS_BOOKKEEPING_KINDS.map(() => "?").join(", ");
 	let query = `
 		SELECT id, name, type, trust_tier, access_count, summary
 		FROM graph_nodes
@@ -48,9 +50,9 @@ export async function handleNousCuriosity(
 			AND access_count <= ?
 			AND t_valid_until IS NULL
 			AND archived_at IS NULL
-			AND (kind IS NULL OR kind NOT IN ('Episode', 'Signal', 'Concern', 'Preference'))
+			AND (kind IS NULL OR kind NOT IN (${bookkeepingPlaceholders}))
 	`;
-	const params: SQLQueryBindings[] = [MIN_TRUST_TIER, MAX_ACCESS_COUNT];
+	const params: SQLQueryBindings[] = [MIN_TRUST_TIER, MAX_ACCESS_COUNT, ...NOUS_BOOKKEEPING_KINDS];
 
 	if (input.topic) {
 		query += " AND (name LIKE ? OR summary LIKE ?)";

--- a/src/mcp/tools/nous-state.ts
+++ b/src/mcp/tools/nous-state.ts
@@ -2,9 +2,18 @@
 //
 // Read-only: projects the session's current driftScore, active Preference nodes,
 // recent Signal nodes, surprise count, session type, and the nous_modify gate bit.
+// Also emits a `next_steps` hint that chains to nous_reflect (on drift warning)
+// or nous_curiosity (when no open Concerns and untouched high-trust entities exist).
 
 import type { SiaDb } from "@/graph/db-interface";
+import { MAX_ACCESS_COUNT } from "@/mcp/tools/nous-curiosity";
+import { DEFAULT_NOUS_CONFIG, NOUS_BOOKKEEPING_KINDS } from "@/nous/types";
 import { getSession } from "@/nous/working-memory";
+
+export interface NousStateNextStep {
+	tool: "nous_reflect" | "nous_curiosity";
+	reason: string;
+}
 
 export interface NousStateResult {
 	driftScore: number;
@@ -14,6 +23,7 @@ export interface NousStateResult {
 	sessionType: string;
 	parentSessionId: string | null;
 	nousModifyBlocked: boolean;
+	next_steps: NousStateNextStep[];
 }
 
 export async function handleNousState(db: SiaDb, sessionId: string): Promise<NousStateResult> {
@@ -28,6 +38,7 @@ export async function handleNousState(db: SiaDb, sessionId: string): Promise<Nou
 			sessionType: "unknown",
 			parentSessionId: null,
 			nousModifyBlocked: false,
+			next_steps: [],
 		};
 	}
 
@@ -43,6 +54,11 @@ export async function handleNousState(db: SiaDb, sessionId: string): Promise<Nou
 			sessionType: session.session_type,
 			parentSessionId: session.parent_session_id,
 			nousModifyBlocked: state.nousModifyBlocked,
+			next_steps: buildNextSteps({
+				driftScore: state.driftScore,
+				openConcernCount: 0,
+				untouchedHighTrustCount: 0,
+			}),
 		};
 	}
 
@@ -64,6 +80,31 @@ export async function handleNousState(db: SiaDb, sessionId: string): Promise<Nou
 		)
 		.all(sessionId) as Array<{ signal_type: string; score: number; description: string }>;
 
+	// Count open Concerns (status:open tag) — used to decide whether to nudge toward nous_curiosity.
+	const openConcernRow = raw
+		.prepare(
+			"SELECT COUNT(*) as cnt FROM graph_nodes WHERE kind = 'Concern' AND tags LIKE '%status:open%' AND t_valid_until IS NULL AND archived_at IS NULL",
+		)
+		.get() as { cnt: number } | undefined;
+	const openConcernCount = openConcernRow?.cnt ?? 0;
+
+	// Count untouched/rarely-retrieved high-trust entities (trust_tier <= 2,
+	// access_count <= MAX_ACCESS_COUNT, live).
+	// Threshold and bookkeeping-kind exclusion must match nous_curiosity exactly
+	// so the hint fires on precisely the entities that tool would return.
+	const bookkeepingPlaceholders = NOUS_BOOKKEEPING_KINDS.map(() => "?").join(", ");
+	const untouchedRow = raw
+		.prepare(
+			`SELECT COUNT(*) as cnt FROM graph_nodes
+			 WHERE trust_tier <= 2
+			   AND access_count <= ?
+			   AND t_valid_until IS NULL
+			   AND archived_at IS NULL
+			   AND (kind IS NULL OR kind NOT IN (${bookkeepingPlaceholders}))`,
+		)
+		.get(MAX_ACCESS_COUNT, ...NOUS_BOOKKEEPING_KINDS) as { cnt: number } | undefined;
+	const untouchedHighTrustCount = untouchedRow?.cnt ?? 0;
+
 	return {
 		driftScore: state.driftScore,
 		preferences,
@@ -72,5 +113,35 @@ export async function handleNousState(db: SiaDb, sessionId: string): Promise<Nou
 		sessionType: session.session_type,
 		parentSessionId: session.parent_session_id,
 		nousModifyBlocked: state.nousModifyBlocked,
+		next_steps: buildNextSteps({
+			driftScore: state.driftScore,
+			openConcernCount,
+			untouchedHighTrustCount,
+		}),
 	};
+}
+
+function buildNextSteps(args: {
+	driftScore: number;
+	openConcernCount: number;
+	untouchedHighTrustCount: number;
+}): NousStateNextStep[] {
+	const steps: NousStateNextStep[] = [];
+	const threshold = DEFAULT_NOUS_CONFIG.driftWarningThreshold;
+
+	if (args.driftScore > threshold) {
+		steps.push({
+			tool: "nous_reflect",
+			reason: `drift score ${args.driftScore.toFixed(2)} exceeds warning threshold ${threshold.toFixed(2)} — reflect before continuing`,
+		});
+	}
+
+	if (args.openConcernCount === 0 && args.untouchedHighTrustCount > 0) {
+		steps.push({
+			tool: "nous_curiosity",
+			reason: `no open Concerns and ${args.untouchedHighTrustCount} unretrieved high-trust entit${args.untouchedHighTrustCount === 1 ? "y" : "ies"} — explore the graph for knowledge gaps`,
+		});
+	}
+
+	return steps;
 }

--- a/src/nous/types.ts
+++ b/src/nous/types.ts
@@ -58,3 +58,20 @@ export const DEFAULT_SESSION_STATE: NousSessionState = {
 	toolCallCount: 0,
 	sessionStartedAt: 0,
 };
+
+/**
+ * Bookkeeping `kind` values that should never be surfaced by curiosity-style
+ * retrieval. Shared between `nous_curiosity` (the retrieval tool) and
+ * `nous_state` (the hint emitter) so both use identical exclusion sets.
+ *
+ * These kinds are pure session/meta bookkeeping: they record events, prompts,
+ * flags, and per-session cognitive state rather than knowledge worth exploring.
+ */
+export const NOUS_BOOKKEEPING_KINDS = [
+	"Episode",
+	"Signal",
+	"Concern",
+	"Preference",
+	"UserPrompt",
+	"SessionFlag",
+] as const;

--- a/tests/unit/mcp/tools/nous-state.test.ts
+++ b/tests/unit/mcp/tools/nous-state.test.ts
@@ -2,15 +2,59 @@ import { randomUUID } from "node:crypto";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { v4 as uuid } from "uuid";
 import { afterEach, describe, expect, it } from "vitest";
 import type { SiaDb } from "@/graph/db-interface";
 import { openGraphDb } from "@/graph/semantic-db";
 import { handleNousState } from "@/mcp/tools/nous-state";
-import { DEFAULT_SESSION_STATE } from "@/nous/types";
+import { DEFAULT_NOUS_CONFIG, DEFAULT_SESSION_STATE } from "@/nous/types";
 import { upsertSession } from "@/nous/working-memory";
 
 function makeTmp(): string {
 	return join(tmpdir(), `nous-st-${randomUUID()}`);
+}
+
+/** Test helper: insert a minimal graph_nodes row. */
+function insertNode(
+	db: SiaDb,
+	opts: {
+		id: string;
+		type: string;
+		name: string;
+		trust_tier: number;
+		access_count: number;
+		kind?: string | null;
+		tags?: string;
+	},
+): void {
+	const raw = db.rawSqlite();
+	if (!raw) throw new Error("no raw sqlite handle");
+	const now = Date.now();
+	raw
+		.prepare(
+			`INSERT INTO graph_nodes (
+			id, type, name, content, summary,
+			tags, file_paths,
+			trust_tier, confidence, base_confidence,
+			importance, base_importance,
+			access_count, edge_count,
+			last_accessed, created_at, t_created,
+			visibility, created_by,
+			kind
+		) VALUES (?, ?, ?, 'content', 'summary', ?, '[]', ?, 0.9, 0.9, 0.5, 0.5, ?, 0, ?, ?, ?, 'private', 'test', ?)`,
+		)
+		.run(
+			opts.id,
+			opts.type,
+			opts.name,
+			opts.tags ?? "[]",
+			opts.trust_tier,
+			opts.access_count,
+			now,
+			now,
+			now,
+			opts.kind ?? null,
+		);
 }
 
 describe("nous-state", () => {
@@ -44,6 +88,7 @@ describe("nous-state", () => {
 		expect(result.sessionType).toBe("primary");
 		expect(Array.isArray(result.preferences)).toBe(true);
 		expect(Array.isArray(result.recentSignals)).toBe(true);
+		expect(Array.isArray(result.next_steps)).toBe(true);
 	});
 
 	it("returns empty state when session not found", async () => {
@@ -53,5 +98,102 @@ describe("nous-state", () => {
 		const result = await handleNousState(db, "nonexistent");
 		expect(result.driftScore).toBe(0);
 		expect(result.sessionType).toBe("unknown");
+		expect(result.next_steps).toEqual([]);
+	});
+
+	it("emits a nous_reflect next-step when drift score exceeds the warning threshold", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-ns-drift", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+		const driftAboveThreshold = DEFAULT_NOUS_CONFIG.driftWarningThreshold + 0.1;
+		upsertSession(db, {
+			session_id: "st-sess-drift",
+			parent_session_id: null,
+			session_type: "primary",
+			state: { ...DEFAULT_SESSION_STATE, driftScore: driftAboveThreshold },
+			created_at: now,
+			updated_at: now,
+		});
+
+		const result = await handleNousState(db, "st-sess-drift");
+		const reflectStep = result.next_steps.find((s) => s.tool === "nous_reflect");
+		expect(reflectStep).toBeDefined();
+		expect(reflectStep?.reason).toContain("drift score");
+		expect(reflectStep?.reason).toContain(DEFAULT_NOUS_CONFIG.driftWarningThreshold.toFixed(2));
+	});
+
+	it("emits a nous_curiosity next-step when no open Concerns exist and untouched high-trust entities are present", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-ns-curiosity", tmpDir);
+
+		// Seed a high-trust, rarely-retrieved Decision node. access_count = 2 is
+		// within nous_curiosity's MAX_ACCESS_COUNT (3) threshold, so the hint
+		// must still fire — proves nous_state and nous_curiosity use the same
+		// access-count threshold.
+		insertNode(db, {
+			id: uuid(),
+			type: "Decision",
+			name: "Rarely-retrieved Decision",
+			trust_tier: 1,
+			access_count: 2,
+			kind: "Decision",
+		});
+
+		const now = Math.floor(Date.now() / 1000);
+		upsertSession(db, {
+			session_id: "st-sess-curio",
+			parent_session_id: null,
+			session_type: "primary",
+			// Drift well below the warning threshold so only the curiosity branch fires.
+			state: { ...DEFAULT_SESSION_STATE, driftScore: 0.1 },
+			created_at: now,
+			updated_at: now,
+		});
+
+		const result = await handleNousState(db, "st-sess-curio");
+		const curiosityStep = result.next_steps.find((s) => s.tool === "nous_curiosity");
+		expect(curiosityStep).toBeDefined();
+		expect(curiosityStep?.reason).toContain("no open Concerns");
+		// Ensure the drift branch did NOT fire.
+		expect(result.next_steps.find((s) => s.tool === "nous_reflect")).toBeUndefined();
+	});
+
+	it("omits the nous_curiosity next-step when open Concerns already exist", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-ns-openconcern", tmpDir);
+
+		// Seed an open Concern (should suppress the curiosity hint).
+		insertNode(db, {
+			id: uuid(),
+			type: "Concern",
+			name: "Existing open concern",
+			trust_tier: 3,
+			access_count: 0,
+			kind: "Concern",
+			tags: '["status:open"]',
+		});
+		// Seed an untouched high-trust entity (would normally trigger curiosity).
+		insertNode(db, {
+			id: uuid(),
+			type: "Decision",
+			name: "Unretrieved Decision 2",
+			trust_tier: 1,
+			access_count: 0,
+			kind: "Decision",
+		});
+
+		const now = Math.floor(Date.now() / 1000);
+		upsertSession(db, {
+			session_id: "st-sess-openconcern",
+			parent_session_id: null,
+			session_type: "primary",
+			state: { ...DEFAULT_SESSION_STATE, driftScore: 0.1 },
+			created_at: now,
+			updated_at: now,
+		});
+
+		const result = await handleNousState(db, "st-sess-openconcern");
+		expect(result.next_steps.find((s) => s.tool === "nous_curiosity")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

- **CLAUDE.md contracts**: tighten `nous_curiosity` wording (adds "Call after any long-form task completes — before ending your turn" mandate) and `/sia-playbooks` mandate ("you MUST invoke ... before any Sia tool call").
- **9 trig-0 skill descriptions** rewritten with superpowers-style "Use when X / before Y" triggers (all 9 named in the commit).
- **3 agent frontmatters**: `sia-knowledge-capture` + `sia-pr-writer` each gain 3 `<example>` blocks; `sia-onboarding` gains an "Orientation Step (Always First)" section that opens with `sia_community({level:2})`.
- **`nous_state`** response includes a new `next_steps` field chaining to `nous_reflect` on drift-warning and `nous_curiosity` on unread high-trust entities. Threshold + bookkeeping-kind exclusion shared with `nous_curiosity` via `NOUS_BOOKKEEPING_KINDS` and `MAX_ACCESS_COUNT`.

Source plan: `docs/superpowers/plans/2026-04-21-roadmap-execution.md` Phase B1 (gitignored).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (558 files)
- [x] `bun run test` — 2028/2028 pass
- [x] `bash scripts/validate-plugin.sh` — 9/9 OK
- [x] `bash scripts/count-plugin-components.sh` — skills 47, agents 26, MCP 29 (unchanged)