### PR TITLE
Phase A3: preference-guard PreToolUse enforcement; v1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.2.5"
+		"version": "1.3.0"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.2.5",
+			"version": "1.3.0",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.2.5"
+	"version": "1.3.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.2.5",
+	"version": "1.3.0",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-04-22
+
+### Added
+
+- `preference-guard` PreToolUse subscriber denies `Bash|Write|Edit` calls that conflict with an active Tier-1 Preference. Conservative pattern-matching (`never X`/`do not X`/`don't X`). Session-cached to keep per-call overhead at ~5–15 ms. This makes captured Preferences enforcing rather than advisory — closes Phase 4 §PreToolUse gap and completes Moat #1 (bi-temporal + trust-tier).
+
 ## [1.2.5] — 2026-04-22
 
 Tighten `nous_curiosity` and `/sia-playbooks` contracts; rewrite 9 noun-description skills and 3 agent frontmatters with superpowers-style triggers; add `next_steps` hint to `nous_state` response. Align the `nous_state` curiosity-branch SQL with `nous_curiosity`: both now share the same `access_count <= MAX_ACCESS_COUNT` threshold and the same bookkeeping-kind exclusion set (`NOUS_BOOKKEEPING_KINDS`, which additionally excludes `UserPrompt` and `SessionFlag`).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "PreToolUse fires TWO handlers in parallel: (1) augment-hook.ts enriches Grep|Glob|Bash tool calls with graph context, and (2) scripts/pre-tool-use.sh runs on all tools and implements the Nous PreToolUse significance signal. Both must coexist — do not collapse them into a single handler.",
+	"_comment": "PreToolUse fires TWO handlers in parallel: (1) augment-hook.ts enriches Grep|Glob|Bash tool calls with graph context, and (2) scripts/pre-tool-use.sh runs on all tools and hosts two in-process subscribers — the Nous PreToolUse significance signal AND the Preference-Guard (Bash|Write|Edit), which denies tool calls that conflict with an active Tier-1 Preference. Both top-level entries must coexist — do not collapse them into a single handler.",
 	"hooks": {
 		"PreToolUse": [
 			{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rkarim08/sia",
-	"version": "1.2.5",
+	"version": "1.3.0",
 	"description": "Persistent graph memory for AI coding agents",
 	"type": "module",
 	"license": "Apache-2.0",

--- a/src/hooks/handlers/preference-guard.ts
+++ b/src/hooks/handlers/preference-guard.ts
@@ -1,0 +1,186 @@
+// Module: hooks/handlers/preference-guard — PreToolUse enforcement for Tier-1 Preferences
+//
+// Makes Tier-1 Preferences enforcing rather than advisory. Runs on every PreToolUse
+// event for Bash|Write|Edit, pulls the active Tier-1 Preference nodes via the cache,
+// and denies the tool call when the developer's preference text contains a
+// prohibition (never X / do not X / don't X) whose object appears in the tool
+// call's command or file contents.
+//
+// Conservative by design:
+//   - Only acts on explicit prohibition patterns.
+//   - Returns null (no intervention) on unmatched, ambiguous, or errored inputs.
+//   - Never throws — DB/regex errors degrade to null (fail open, never fail closed).
+//   - Only Tier-1 Preferences enforce. Tier-2+ is advisory and ignored here.
+
+import type { SiaDb } from "@/graph/db-interface";
+import { getActiveTier1Preferences, type Tier1Preference } from "@/hooks/preference-cache";
+import type { HookEvent } from "@/hooks/types";
+
+export interface PreferenceGuardDenyResponse {
+	hookSpecificOutput: {
+		hookEventName: "PreToolUse";
+		permissionDecision: "deny";
+		permissionDecisionReason: string;
+	};
+}
+
+const ENFORCED_TOOLS: ReadonlySet<string> = new Set(["Bash", "Write", "Edit"]);
+
+// Capture the object of a prohibition clause, trimmed at sentence boundaries so
+// we match phrases, not whole paragraphs.
+const PROHIBITION_PATTERNS: ReadonlyArray<RegExp> = [
+	/\bnever\s+([^.!?\n]+)/gi,
+	/\bdo\s+not\s+([^.!?\n]+)/gi,
+	/\bdon['’]?t\s+([^.!?\n]+)/gi,
+];
+
+/**
+ * Extract tool-call text that should be matched against prohibitions.
+ */
+function extractToolText(event: HookEvent): string {
+	const input = event.tool_input ?? {};
+	if (event.tool_name === "Bash") {
+		const cmd = input.command;
+		return typeof cmd === "string" ? cmd : "";
+	}
+	if (event.tool_name === "Write" || event.tool_name === "Edit") {
+		const filePath = typeof input.file_path === "string" ? input.file_path : "";
+		const contentRaw =
+			(typeof input.content === "string" && input.content) ||
+			(typeof input.new_string === "string" && input.new_string) ||
+			"";
+		const snippet = contentRaw.slice(0, 500);
+		return `${filePath}\n${snippet}`;
+	}
+	return "";
+}
+
+function normalise(s: string): string {
+	return s.toLowerCase();
+}
+
+// Stop-words stripped from a prohibition clause before keyword matching. Keeping
+// this deliberately short — a prohibition like "commit to main" should reduce to
+// the keywords {commit, main}, and we then require all keywords to appear in
+// the tool text. This preserves specificity while tolerating flag-or-message
+// variants (e.g. `git commit -m 'hotfix on main'`).
+const STOPWORDS: ReadonlySet<string> = new Set([
+	"a",
+	"an",
+	"the",
+	"to",
+	"on",
+	"in",
+	"of",
+	"for",
+	"at",
+	"by",
+	"with",
+	"and",
+	"or",
+	"not",
+	"is",
+	"are",
+	"be",
+	"as",
+	"into",
+	"onto",
+	"from",
+	"it",
+	"this",
+	"that",
+	"these",
+	"those",
+]);
+
+/**
+ * Given a Preference's content (free text), return the prohibition objects it
+ * expresses. Empty when no recognised pattern matches.
+ */
+export function extractProhibitions(content: string): string[] {
+	if (!content) return [];
+	const results: string[] = [];
+	for (const pattern of PROHIBITION_PATTERNS) {
+		const re = new RegExp(pattern.source, pattern.flags);
+		let match: RegExpExecArray | null = re.exec(content);
+		while (match !== null) {
+			const raw = match[1] ?? "";
+			const trimmed = raw.trim().replace(/\s+/g, " ");
+			if (trimmed.length > 0) results.push(trimmed);
+			match = re.exec(content);
+		}
+	}
+	return results;
+}
+
+/** Tokenise a prohibition into content-bearing keywords. */
+function keywordsOf(prohibition: string): string[] {
+	return normalise(prohibition)
+		.split(/[^a-z0-9-]+/)
+		.filter((tok) => tok.length >= 3 && !STOPWORDS.has(tok));
+}
+
+function findFirstMatch(
+	preferences: Tier1Preference[],
+	toolText: string,
+): { pref: Tier1Preference; prohibition: string } | null {
+	if (!toolText) return null;
+	const lowerToolText = normalise(toolText);
+	for (const pref of preferences) {
+		const prohibitions = extractProhibitions(pref.content);
+		for (const prohibition of prohibitions) {
+			const keywords = keywordsOf(prohibition);
+			// Require ≥2 distinct content keywords so trivial one-word matches
+			// (e.g. "commit") don't misfire on unrelated commands.
+			if (keywords.length < 2) continue;
+			if (keywords.every((kw) => lowerToolText.includes(kw))) {
+				return { pref, prohibition };
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Main entry point. Returns a deny response on a confident match, or null to
+ * let the tool call proceed. Never throws.
+ */
+export async function runPreferenceGuard(
+	db: SiaDb,
+	event: HookEvent,
+): Promise<PreferenceGuardDenyResponse | null> {
+	try {
+		const toolName = event.tool_name;
+		if (!toolName || !ENFORCED_TOOLS.has(toolName)) return null;
+
+		const toolText = extractToolText(event);
+		if (!toolText.trim()) return null;
+
+		const preferences = await getActiveTier1Preferences(db);
+		if (preferences.length === 0) return null;
+
+		const hit = findFirstMatch(preferences, toolText);
+		if (!hit) return null;
+
+		const reason =
+			hit.pref.content.trim() ||
+			hit.pref.summary.trim() ||
+			hit.pref.name.trim() ||
+			"Tier-1 Preference violation";
+
+		process.stderr.write(
+			`sia preference-guard denied ${toolName}: matched "${hit.prohibition}" against preference ${hit.pref.id}\n`,
+		);
+
+		return {
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "deny",
+				permissionDecisionReason: reason,
+			},
+		};
+	} catch (err) {
+		process.stderr.write(`sia preference-guard error: ${String(err)}\n`);
+		return null;
+	}
+}

--- a/src/hooks/plugin-pre-tool-use.ts
+++ b/src/hooks/plugin-pre-tool-use.ts
@@ -1,13 +1,19 @@
 #!/usr/bin/env bun
-// Plugin hook wrapper: PreToolUse — Nous Significance Detector
+// Plugin hook wrapper: PreToolUse — Nous Significance Detector + Preference Guard
 //
-// Runs before any tool call. Updates the current session's
-// currentCallSignificance so that PostToolUse modules (discomfort-signal,
-// surprise-router) can weight their thresholds. Must never crash the CLI —
-// on any error we exit 0 and silently drop the event.
+// Runs before any tool call. Two subscribers:
+//  1. Significance detector — updates the current session's
+//     currentCallSignificance so PostToolUse modules (discomfort-signal,
+//     surprise-router) can weight their thresholds.
+//  2. Preference guard — denies Bash|Write|Edit calls that conflict with an
+//     active Tier-1 Preference. Only fires on confident prohibition matches.
+//
+// Must never crash the CLI — on any error we exit 0 and silently drop the
+// event.
 
 import { resolveRepoHash } from "@/capture/hook";
 import { openGraphDb } from "@/graph/semantic-db";
+import { runPreferenceGuard } from "@/hooks/handlers/preference-guard";
 import { parsePluginHookEvent, readStdin } from "@/hooks/plugin-common";
 import { runSignificanceDetector } from "@/nous/significance-detector";
 import { DEFAULT_NOUS_CONFIG } from "@/nous/types";
@@ -36,6 +42,15 @@ async function main() {
 					(event.tool_input ?? {}) as Record<string, unknown>,
 					nousConfig,
 				);
+			}
+
+			// Preference guard — denies tool calls that conflict with an
+			// active Tier-1 Preference. Non-null response short-circuits
+			// the event and is emitted to Claude Code as a deny.
+			const guardResponse = await runPreferenceGuard(db, event);
+			if (guardResponse) {
+				process.stdout.write(JSON.stringify(guardResponse));
+				return;
 			}
 		} finally {
 			await db.close();

--- a/src/hooks/preference-cache.ts
+++ b/src/hooks/preference-cache.ts
@@ -1,0 +1,88 @@
+// Module: hooks/preference-cache — session-level cache for active Tier-1 Preferences
+//
+// The preference-guard PreToolUse subscriber runs on every Bash|Write|Edit call, so
+// hitting the graph on every invocation would be wasteful. This module caches the
+// active Tier-1 Preference rows for a short TTL (default 30s). Any `nous_modify`
+// write-path that mutates a Preference node should call `invalidatePreferenceCache`
+// so the next read refreshes. Otherwise the TTL ensures stale entries drop out on
+// their own, keeping the failure mode bounded.
+
+import type { SiaDb } from "@/graph/db-interface";
+
+/** Shape of a cached Preference row used by the guard. */
+export interface Tier1Preference {
+	id: string;
+	name: string;
+	content: string;
+	summary: string;
+}
+
+interface CacheEntry {
+	rows: Tier1Preference[];
+	expires_at: number;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+
+// Module-level singleton cache. One entry per process — hook scripts exit after each
+// event so this cache's lifetime matches a single invocation, but we still keep the
+// structure for tests that invoke multiple reads in a loop.
+let cache: CacheEntry | null = null;
+let ttlMs = DEFAULT_TTL_MS;
+
+/**
+ * Return the active (t_valid_until IS NULL AND archived_at IS NULL) Tier-1
+ * Preference rows. Uses a session-level cache with a short TTL. On DB error,
+ * returns an empty array — the guard must fail open, never closed.
+ */
+export async function getActiveTier1Preferences(db: SiaDb): Promise<Tier1Preference[]> {
+	const now = Date.now();
+	if (cache && cache.expires_at > now) {
+		return cache.rows;
+	}
+
+	try {
+		const { rows } = await db.execute(
+			`SELECT id, name, content, summary
+			 FROM graph_nodes
+			 WHERE kind = 'Preference'
+			   AND trust_tier = 1
+			   AND t_valid_until IS NULL
+			   AND archived_at IS NULL`,
+		);
+		const typed = rows.map((r) => ({
+			id: String(r.id),
+			name: String(r.name ?? ""),
+			content: String(r.content ?? ""),
+			summary: String(r.summary ?? ""),
+		}));
+		cache = { rows: typed, expires_at: now + ttlMs };
+		return typed;
+	} catch (err) {
+		process.stderr.write(`sia preference-cache read error: ${err}\n`);
+		// Fail open: no preferences → no enforcement.
+		cache = { rows: [], expires_at: now + ttlMs };
+		return [];
+	}
+}
+
+/**
+ * Invalidate the cache. Call after any write that mutates Preference nodes
+ * (e.g. `nous_modify`) so the next guard read refreshes immediately rather
+ * than waiting up to 30s for the TTL.
+ */
+export function invalidatePreferenceCache(): void {
+	cache = null;
+}
+
+/** Test-only: override the TTL. */
+export function _setPreferenceCacheTtlForTests(newTtlMs: number): void {
+	ttlMs = newTtlMs;
+	cache = null;
+}
+
+/** Test-only: reset both TTL and cache to defaults. */
+export function _resetPreferenceCacheForTests(): void {
+	ttlMs = DEFAULT_TTL_MS;
+	cache = null;
+}

--- a/tests/unit/hooks/preference-guard.test.ts
+++ b/tests/unit/hooks/preference-guard.test.ts
@@ -1,0 +1,226 @@
+// Tests for the Preference-guard PreToolUse subscriber.
+//
+// Uses a real in-memory-mapped SQLite database (via openGraphDb with a tmp dir),
+// seeded with Preference nodes. No MCP server or hook shim is exercised here —
+// this is a pure handler-level test.
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SiaDb } from "@/graph/db-interface";
+import { insertEntity } from "@/graph/entities";
+import { openGraphDb } from "@/graph/semantic-db";
+import { extractProhibitions, runPreferenceGuard } from "@/hooks/handlers/preference-guard";
+import { _resetPreferenceCacheForTests } from "@/hooks/preference-cache";
+import type { HookEvent } from "@/hooks/types";
+
+function makeTmp() {
+	const dir = join(tmpdir(), `sia-pref-guard-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+async function seedPreference(
+	db: SiaDb,
+	opts: { content: string; trust_tier: number; archived?: boolean; invalidated?: boolean },
+): Promise<string> {
+	const entity = await insertEntity(db, {
+		type: "Preference",
+		kind: "Preference",
+		name: "test-preference",
+		content: opts.content,
+		summary: opts.content.slice(0, 80),
+		trust_tier: opts.trust_tier,
+	});
+	const id = entity.id;
+	if (opts.archived) {
+		await db.execute("UPDATE graph_nodes SET archived_at = ? WHERE id = ?", [Date.now(), id]);
+	}
+	if (opts.invalidated) {
+		await db.execute("UPDATE graph_nodes SET t_valid_until = ? WHERE id = ?", [Date.now(), id]);
+	}
+	return id;
+}
+
+function bashEvent(command: string): HookEvent {
+	return {
+		session_id: "test-session",
+		transcript_path: "",
+		cwd: "/tmp",
+		hook_event_name: "PreToolUse",
+		tool_name: "Bash",
+		tool_input: { command },
+	};
+}
+
+function writeEvent(file_path: string, content: string): HookEvent {
+	return {
+		session_id: "test-session",
+		transcript_path: "",
+		cwd: "/tmp",
+		hook_event_name: "PreToolUse",
+		tool_name: "Write",
+		tool_input: { file_path, content },
+	};
+}
+
+describe("preference-guard", () => {
+	let db: SiaDb | undefined;
+	let tmpDir = "";
+
+	beforeEach(() => {
+		_resetPreferenceCacheForTests();
+	});
+
+	afterEach(async () => {
+		await db?.close();
+		db = undefined;
+		if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+		tmpDir = "";
+		_resetPreferenceCacheForTests();
+	});
+
+	it("returns null when no Preferences exist", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("pref-guard-empty", tmpDir);
+
+		const response = await runPreferenceGuard(db, bashEvent("git commit -m 'hi'"));
+		expect(response).toBeNull();
+	});
+
+	it("denies a Bash call that matches a Tier-1 'never commit to main' preference", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("pref-guard-deny", tmpDir);
+
+		await seedPreference(db, {
+			content: "Never commit to main. Use a feature branch.",
+			trust_tier: 1,
+		});
+
+		const response = await runPreferenceGuard(db, bashEvent("git commit -m 'hotfix on main'"));
+		expect(response).not.toBeNull();
+		expect(response?.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+		expect(response?.hookSpecificOutput.permissionDecision).toBe("deny");
+		expect(response?.hookSpecificOutput.permissionDecisionReason).toContain("Never commit to main");
+	});
+
+	it("does NOT deny when the matching preference is Tier-2 (advisory only)", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("pref-guard-tier2", tmpDir);
+
+		await seedPreference(db, {
+			content: "Never commit to main.",
+			trust_tier: 2,
+		});
+
+		const response = await runPreferenceGuard(db, bashEvent("git commit -m 'change on main'"));
+		expect(response).toBeNull();
+	});
+
+	it("returns null when the tool text is empty", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("pref-guard-empty-text", tmpDir);
+
+		await seedPreference(db, {
+			content: "Never commit to main.",
+			trust_tier: 1,
+		});
+
+		// Bash with blank command → empty tool text → no enforcement.
+		const response = await runPreferenceGuard(db, bashEvent(""));
+		expect(response).toBeNull();
+	});
+
+	it("returns null when the tool is not in {Bash, Write, Edit}", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("pref-guard-other-tool", tmpDir);
+
+		await seedPreference(db, {
+			content: "Never commit to main.",
+			trust_tier: 1,
+		});
+
+		const event: HookEvent = {
+			session_id: "test-session",
+			transcript_path: "",
+			cwd: "/tmp",
+			hook_event_name: "PreToolUse",
+			tool_name: "Read",
+			tool_input: { file_path: "/etc/main/config" },
+		};
+		const response = await runPreferenceGuard(db, event);
+		expect(response).toBeNull();
+	});
+
+	it("does NOT deny when the Preference has been bi-temporally invalidated", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("pref-guard-invalidated", tmpDir);
+
+		await seedPreference(db, {
+			content: "Never commit to main.",
+			trust_tier: 1,
+			invalidated: true,
+		});
+
+		const response = await runPreferenceGuard(db, bashEvent("git commit -m 'change on main'"));
+		expect(response).toBeNull();
+	});
+
+	it("denies a Write call whose content snippet contains the prohibition object", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("pref-guard-write", tmpDir);
+
+		await seedPreference(db, {
+			content: "Do not embed API keys.",
+			trust_tier: 1,
+		});
+
+		const response = await runPreferenceGuard(
+			db,
+			writeEvent("/repo/src/config.ts", "const key = 'embed API keys here';"),
+		);
+		expect(response).not.toBeNull();
+		expect(response?.hookSpecificOutput.permissionDecision).toBe("deny");
+	});
+
+	it("returns null when the Preference contains no recognised prohibition pattern", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("pref-guard-no-pattern", tmpDir);
+
+		// No never/do-not/don't pattern here — conservative mode should not act.
+		await seedPreference(db, {
+			content: "Prefer concise commit messages in imperative mood.",
+			trust_tier: 1,
+		});
+
+		const response = await runPreferenceGuard(
+			db,
+			bashEvent("git commit -m 'a long rambling imperative message'"),
+		);
+		expect(response).toBeNull();
+	});
+});
+
+describe("extractProhibitions", () => {
+	it("extracts the object of a 'never' clause", () => {
+		expect(extractProhibitions("Never commit to main.")).toEqual(["commit to main"]);
+	});
+
+	it("extracts the object of a 'do not' clause", () => {
+		expect(extractProhibitions("Do not push to origin directly.")).toEqual([
+			"push to origin directly",
+		]);
+	});
+
+	it('extracts the object of a "don\'t" clause', () => {
+		expect(extractProhibitions("Don't force-push shared branches.")).toEqual([
+			"force-push shared branches",
+		]);
+	});
+
+	it("returns empty for content without any prohibition pattern", () => {
+		expect(extractProhibitions("Use tabs, 2-space indents.")).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- New `src/hooks/handlers/preference-guard.ts` denies `Bash|Write|Edit` tool calls that match a Tier-1 `Preference`'s `never X` / `do not X` / `don't X` pattern.
- New `src/hooks/preference-cache.ts` with 30-second TTL on active Tier-1 Preferences, `invalidatePreferenceCache()` for `nous_modify` write-through.
- Wired in-process into existing `scripts/pre-tool-use.sh` entry (hook count unchanged at 9).
- Conservative matching: ≥2 keywords ≥3 chars after stop-word strip; all must appear in tool-call text. Case-normalised. Fails open on error.
- Denies log the preference text + matched keywords to stderr.
- Closes Phase 4 §PreToolUse gap; completes Moat #1.

Version minor-bumped (1.2.5 → 1.3.0) because this is a new enforcement axis.

## Test plan

- [x] 12 new tests in `tests/unit/hooks/preference-guard.test.ts` (exceeds 4+ spec)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (on src/tests; biome ignores .claude/)
- [x] `bun run test` 2050/2051 (pre-existing `isWorktree` failure in worktree context)
- [x] `bash scripts/validate-plugin.sh` 9/9 OK