### PR TITLE
Phase A7: Stop drift recompute + SubagentEpisode; v1.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.3.0"
+		"version": "1.3.3"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.3.0",
+			"version": "1.3.3",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.3.0"
+	"version": "1.3.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.3.0",
+	"version": "1.3.3",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.3.3] — 2026-04-22
+
+### Added
+
+- Stop hook now (a) runs a lightweight drift recompute when stale to catch mid-session divergence and (b) writes a new `SubagentEpisode` node kind for subagent-session Stops so every session gets an audit trail. Episodes chain remains primary-only. Closes Phase 4 §Stop gap. (fixes: `recomputeDriftIfStale` now honours its never-throws contract via an outer try/catch that logs to stderr and returns a safe no-op; signals-since-last-drift query scoped to `session_id` to prevent cross-session leakage in multi-agent scenarios.)
+
 ## [1.3.0] — 2026-04-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rkarim08/sia",
-	"version": "1.3.0",
+	"version": "1.3.3",
 	"description": "Persistent graph memory for AI coding agents",
 	"type": "module",
 	"license": "Apache-2.0",

--- a/src/hooks/plugin-stop.ts
+++ b/src/hooks/plugin-stop.ts
@@ -9,6 +9,7 @@ import { openGraphDb } from "@/graph/semantic-db";
 import { createStopHandler } from "@/hooks/handlers/stop";
 import { parsePluginHookEvent, readStdin } from "@/hooks/plugin-common";
 import { writeEpisode } from "@/nous/episode-writer";
+import { recomputeDriftIfStale } from "@/nous/self-monitor";
 import { DEFAULT_NOUS_CONFIG } from "@/nous/types";
 import { getConfig } from "@/shared/config";
 
@@ -53,11 +54,18 @@ async function main() {
 				process.stderr.write(`sia: session save failed (non-fatal): ${err}\n`);
 			}
 
-			// Nous: write Episode node for primary sessions
+			// Nous: lightweight drift recompute (catches mid-session divergence
+			// the SessionStart baseline missed) then write Episode/SubagentEpisode.
+			// Drift recompute is best-effort — never let it break the Stop hook.
 			try {
 				const config = getConfig();
 				const nousConfig = config.nous ?? DEFAULT_NOUS_CONFIG;
 				if (nousConfig.enabled && event.session_id) {
+					try {
+						await recomputeDriftIfStale(db, event.session_id, nousConfig);
+					} catch (driftErr) {
+						process.stderr.write(`[Nous] drift recompute failed (non-fatal): ${driftErr}\n`);
+					}
 					await writeEpisode(db, event.session_id, nousConfig);
 				}
 			} catch (err) {

--- a/src/nous/episode-writer.ts
+++ b/src/nous/episode-writer.ts
@@ -2,8 +2,10 @@
 //
 // Fires at Stop. For primary sessions it writes a single Episode graph_node
 // summarising the session (tool calls, drift, discomfort peak, Signal count).
-// Subagent sessions are intentionally skipped — they belong to the parent's
-// narrative and would otherwise pollute the graph with noise.
+// For subagent sessions it writes a SubagentEpisode node with the same schema
+// but a distinct `kind` — subagent episodes do NOT participate in the primary
+// Episode chain and are not counted in primary-session output. This gives every
+// session an audit trail without polluting the Episode narrative.
 // In both cases the nous_sessions row is deleted to keep working memory bounded.
 
 import { v4 as uuid } from "uuid";
@@ -31,7 +33,16 @@ export async function writeEpisode(
 	const now = Date.now();
 	const nowSec = Math.floor(now / 1000);
 
-	if (session.session_type === "primary") {
+	// Both `primary` and `subagent` sessions get an audit-trail node. The
+	// `kind` column differentiates them so downstream retrieval can include
+	// or exclude subagent noise as appropriate. `worktree`-typed sessions
+	// are still skipped — their narrative belongs to the parent worktree.
+	const isPrimary = session.session_type === "primary";
+	const isSubagent = session.session_type === "subagent";
+
+	if (isPrimary || isSubagent) {
+		const nodeKind = isPrimary ? "Episode" : "SubagentEpisode";
+
 		const signalCountRow = raw
 			.prepare(
 				"SELECT COUNT(*) as cnt FROM graph_nodes WHERE kind = 'Signal' AND captured_by_session_id = ?",
@@ -39,7 +50,7 @@ export async function writeEpisode(
 			.get(sessionId) as { cnt: number };
 		const signalCount = signalCountRow.cnt;
 
-		const name = `Episode:${sessionId}`;
+		const name = `${nodeKind}:${sessionId}`;
 		const description = [
 			`Session: ${sessionId}`,
 			`Type: ${session.session_type}`,
@@ -52,6 +63,8 @@ export async function writeEpisode(
 
 		const summary = `Session ${sessionId}: ${session.state.toolCallCount} tool calls, ${signalCount} signals, drift=${session.state.driftScore.toFixed(2)}`;
 
+		// `type` column mirrors `kind` so sqlite filters on either column
+		// agree (same contract as the existing Episode write).
 		raw
 			.prepare(
 				`INSERT INTO graph_nodes (
@@ -65,19 +78,20 @@ export async function writeEpisode(
 				session_id, kind,
 				captured_by_session_id, captured_by_session_type
 			) VALUES (
-				?, 'Episode', ?, ?, ?,
+				?, ?, ?, ?, ?,
 				'[]', '[]',
 				2, 1.0, 1.0,
 				0.5, 0.5,
 				0, 0,
 				?, ?, ?,
 				'private', 'nous',
-				?, 'Episode',
+				?, ?,
 				?, ?
 			)`,
 			)
 			.run(
 				uuid(),
+				nodeKind,
 				name,
 				description,
 				summary,
@@ -85,16 +99,22 @@ export async function writeEpisode(
 				now,
 				now,
 				sessionId,
+				nodeKind,
 				sessionId,
 				session.session_type,
 			);
 
-		appendHistory(db, {
-			session_id: sessionId,
-			event_type: "drift",
-			score: session.state.driftScore,
-			created_at: nowSec,
-		});
+		// Only primary sessions contribute to the drift history chain —
+		// subagent drift is local to the subagent and shouldn't affect the
+		// primary session's running baseline.
+		if (isPrimary) {
+			appendHistory(db, {
+				session_id: sessionId,
+				event_type: "drift",
+				score: session.state.driftScore,
+				created_at: nowSec,
+			});
+		}
 	}
 
 	deleteSession(db, sessionId);

--- a/src/nous/self-monitor.ts
+++ b/src/nous/self-monitor.ts
@@ -129,3 +129,128 @@ function computeDriftScore(history: Array<{ score: number; event_type: string }>
 	const avg = discomfortEvents.reduce((sum, e) => sum + e.score, 0) / discomfortEvents.length;
 	return Math.min(1.0, avg);
 }
+
+/**
+ * Staleness threshold in seconds. If the most recent `drift` event for a
+ * session is older than this (or no drift event exists for the session at
+ * all), `recomputeDriftIfStale` will re-run the drift calculation at Stop.
+ *
+ * Chosen as 120s: short enough that a multi-minute mid-session divergence
+ * gets caught before the Stop hook closes the session, long enough that
+ * sessions shorter than two minutes incur no extra work.
+ */
+export const DRIFT_STALENESS_SECONDS = 120;
+
+export interface RecomputeDriftResult {
+	/** True when the drift score was actually re-calculated and persisted. */
+	recomputed: boolean;
+	/** The session's current drift score after the (optional) recompute. */
+	driftScore: number;
+	/**
+	 * Human-readable reason the recompute ran or was skipped. Useful for
+	 * Stop-hook stderr logging and for tests to assert behaviour.
+	 */
+	reason:
+		| "stale"
+		| "signals-since-last-drift"
+		| "no-prior-drift"
+		| "session-not-found"
+		| "disabled"
+		| "fresh";
+}
+
+/**
+ * Lightweight drift recompute called from the Stop hook. Only re-runs the
+ * drift calculation (against the shared `nous_history` window) if the last
+ * drift event for this session is stale or new discomfort/surprise signals
+ * have been written since. Does NOT re-run the full SessionStart pipeline.
+ *
+ * Never throws — callers can assume a resolved Promise. On internal failure
+ * the error is swallowed and returned as `{ recomputed: false, reason: 'session-not-found' }`
+ * so the Stop hook can continue to `writeEpisode` unaffected.
+ */
+export async function recomputeDriftIfStale(
+	db: SiaDb,
+	sessionId: string,
+	config: NousConfig = DEFAULT_NOUS_CONFIG,
+	now: number = Math.floor(Date.now() / 1000),
+): Promise<RecomputeDriftResult> {
+	try {
+		if (!config.enabled) {
+			return { recomputed: false, driftScore: 0, reason: "disabled" };
+		}
+
+		const raw = db.rawSqlite();
+		if (!raw) {
+			return { recomputed: false, driftScore: 0, reason: "session-not-found" };
+		}
+
+		const sessionRow = raw
+			.prepare("SELECT state FROM nous_sessions WHERE session_id = ?")
+			.get(sessionId) as { state: string } | undefined;
+		if (!sessionRow) {
+			return { recomputed: false, driftScore: 0, reason: "session-not-found" };
+		}
+
+		const state = JSON.parse(sessionRow.state) as NousSessionState;
+
+		// Last drift event for THIS session (the staleness anchor).
+		const lastDriftRow = raw
+			.prepare(
+				"SELECT created_at FROM nous_history WHERE session_id = ? AND event_type = 'drift' ORDER BY created_at DESC LIMIT 1",
+			)
+			.get(sessionId) as { created_at: number } | undefined;
+
+		let reason: RecomputeDriftResult["reason"];
+		if (!lastDriftRow) {
+			reason = "no-prior-drift";
+		} else if (now - lastDriftRow.created_at >= DRIFT_STALENESS_SECONDS) {
+			reason = "stale";
+		} else {
+			// Not yet stale by wall-clock — check whether any signal rows were
+			// written since the last drift anchor. Scope to THIS session so
+			// multi-agent concurrent sessions don't leak signals across each
+			// other's staleness checks.
+			const signalRow = raw
+				.prepare(
+					"SELECT COUNT(*) as cnt FROM nous_history WHERE event_type IN ('discomfort', 'surprise') AND created_at > ? AND session_id = ?",
+				)
+				.get(lastDriftRow.created_at, sessionId) as { cnt: number };
+			if (signalRow.cnt > 0) {
+				reason = "signals-since-last-drift";
+			} else {
+				return { recomputed: false, driftScore: state.driftScore, reason: "fresh" };
+			}
+		}
+
+		const history = getRecentHistory(db, config.historyWindowSize);
+		const driftScore = computeDriftScore(history);
+
+		const newState: NousSessionState = {
+			...state,
+			driftScore,
+			nousModifyBlocked: driftScore > config.selfModifyBlockThreshold,
+		};
+
+		raw
+			.prepare("UPDATE nous_sessions SET state = ?, updated_at = ? WHERE session_id = ?")
+			.run(JSON.stringify(newState), now, sessionId);
+
+		appendHistory(db, {
+			session_id: sessionId,
+			event_type: "drift",
+			score: driftScore,
+			created_at: now,
+		});
+
+		return { recomputed: true, driftScore, reason };
+	} catch (err) {
+		// Contract: never throws. The Stop hook must be able to continue to
+		// writeEpisode unaffected on any internal failure (DB closed, JSON
+		// parse error, prepared-statement failure, etc.).
+		process.stderr.write(
+			`[Nous] recomputeDriftIfStale failed (non-fatal): ${err instanceof Error ? err.message : String(err)}\n`,
+		);
+		return { recomputed: false, driftScore: 0, reason: "session-not-found" };
+	}
+}

--- a/src/nous/types.ts
+++ b/src/nous/types.ts
@@ -69,6 +69,7 @@ export const DEFAULT_SESSION_STATE: NousSessionState = {
  */
 export const NOUS_BOOKKEEPING_KINDS = [
 	"Episode",
+	"SubagentEpisode",
 	"Signal",
 	"Concern",
 	"Preference",

--- a/tests/unit/nous/stop-extensions.test.ts
+++ b/tests/unit/nous/stop-extensions.test.ts
@@ -1,0 +1,429 @@
+// Module: tests/unit/nous/stop-extensions — Phase A7 Stop-hook extensions
+//
+// Covers the two extensions added in roadmap Phase A7:
+//   (a) Lightweight drift recompute at Stop (`recomputeDriftIfStale`), which
+//       catches mid-session divergence that the SessionStart baseline missed.
+//   (b) `SubagentEpisode` node kind so subagent sessions get an audit trail
+//       without polluting the primary Episode chain.
+
+import { randomUUID } from "node:crypto";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SiaDb } from "@/graph/db-interface";
+import { openGraphDb } from "@/graph/semantic-db";
+import { writeEpisode } from "@/nous/episode-writer";
+import { DRIFT_STALENESS_SECONDS, recomputeDriftIfStale } from "@/nous/self-monitor";
+import { DEFAULT_NOUS_CONFIG, DEFAULT_SESSION_STATE } from "@/nous/types";
+import { appendHistory, getSession, upsertSession } from "@/nous/working-memory";
+
+function makeTmp() {
+	return join(tmpdir(), `nous-stopext-${randomUUID()}`);
+}
+
+function seedSession(
+	db: SiaDb,
+	sessionId: string,
+	sessionType: "primary" | "subagent",
+	driftScore = 0.1,
+	createdAt?: number,
+) {
+	const now = createdAt ?? Math.floor(Date.now() / 1000);
+	upsertSession(db, {
+		session_id: sessionId,
+		parent_session_id: sessionType === "subagent" ? "parent-sess" : null,
+		session_type: sessionType,
+		state: { ...DEFAULT_SESSION_STATE, driftScore, toolCallCount: 3 },
+		created_at: now,
+		updated_at: now,
+	});
+}
+
+describe("stop-extensions: recomputeDriftIfStale + SubagentEpisode", () => {
+	let db: SiaDb | undefined;
+	let tmpDir = "";
+
+	afterEach(async () => {
+		await db?.close();
+		db = undefined;
+		if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+		tmpDir = "";
+	});
+
+	// ------------------------------------------------------------------
+	// (a) Primary session Stop → drift recomputed, Episode written,
+	//     no SubagentEpisode produced.
+	// ------------------------------------------------------------------
+	it("primary Stop: recomputes drift when stale and writes an Episode", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-primary", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+
+		// Seed primary session.
+		seedSession(db, "prim-1", "primary", 0.1);
+
+		// Seed a stale baseline drift event so the staleness branch fires,
+		// and a batch of high-discomfort events written AFTER that baseline
+		// so the recompute has something to detect.
+		appendHistory(db, {
+			session_id: "prim-1",
+			event_type: "drift",
+			score: 0.1,
+			created_at: now - (DRIFT_STALENESS_SECONDS + 60),
+		});
+		for (let i = 0; i < 5; i++) {
+			appendHistory(db, {
+				session_id: "prim-1",
+				event_type: "discomfort",
+				score: 0.9,
+				created_at: now - i,
+			});
+		}
+
+		const result = await recomputeDriftIfStale(db, "prim-1", DEFAULT_NOUS_CONFIG, now);
+		expect(result.recomputed).toBe(true);
+		expect(result.reason).toBe("stale");
+		expect(result.driftScore).toBeGreaterThan(0.7);
+
+		// Session row reflects the new drift score.
+		const updated = getSession(db, "prim-1");
+		expect(updated?.state.driftScore).toBeGreaterThan(0.7);
+
+		// writeEpisode for a primary session writes an Episode row,
+		// and does NOT write a SubagentEpisode.
+		await writeEpisode(db, "prim-1");
+		const raw = db.rawSqlite();
+		expect(raw).not.toBeNull();
+		const episode = raw
+			?.prepare("SELECT * FROM graph_nodes WHERE kind = 'Episode' AND captured_by_session_id = ?")
+			.get("prim-1") as Record<string, unknown> | undefined;
+		expect(episode).toBeDefined();
+		expect(episode?.captured_by_session_type).toBe("primary");
+
+		const subEp = raw
+			?.prepare(
+				"SELECT * FROM graph_nodes WHERE kind = 'SubagentEpisode' AND captured_by_session_id = ?",
+			)
+			.get("prim-1");
+		expect(subEp ?? null).toBeNull();
+	});
+
+	// ------------------------------------------------------------------
+	// (b) Subagent session Stop → drift recomputed, SubagentEpisode
+	//     written, no Episode row.
+	// ------------------------------------------------------------------
+	it("subagent Stop: recomputes drift and writes a SubagentEpisode (not an Episode)", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-subagent", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+
+		seedSession(db, "sub-1", "subagent", 0.2);
+		// Force a stale baseline so recompute fires.
+		appendHistory(db, {
+			session_id: "sub-1",
+			event_type: "drift",
+			score: 0.2,
+			created_at: now - (DRIFT_STALENESS_SECONDS + 30),
+		});
+		for (let i = 0; i < 3; i++) {
+			appendHistory(db, {
+				session_id: "sub-1",
+				event_type: "discomfort",
+				score: 0.85,
+				created_at: now - i,
+			});
+		}
+
+		const result = await recomputeDriftIfStale(db, "sub-1", DEFAULT_NOUS_CONFIG, now);
+		expect(result.recomputed).toBe(true);
+		expect(result.driftScore).toBeGreaterThan(0.7);
+
+		await writeEpisode(db, "sub-1");
+
+		const raw = db.rawSqlite();
+		expect(raw).not.toBeNull();
+
+		// SubagentEpisode exists with the subagent session_id retained
+		// for future debugging.
+		const subEp = raw
+			?.prepare(
+				"SELECT * FROM graph_nodes WHERE kind = 'SubagentEpisode' AND captured_by_session_id = ?",
+			)
+			.get("sub-1") as Record<string, unknown> | undefined;
+		expect(subEp).toBeDefined();
+		expect(subEp?.captured_by_session_type).toBe("subagent");
+		// `session_id` is also persisted on the node (separate from
+		// `captured_by_session_id`) so either column can be used to
+		// cross-reference the originating session.
+		expect(subEp?.session_id).toBe("sub-1");
+		// SubagentEpisode must not masquerade as a primary Episode.
+		expect(subEp?.type).toBe("SubagentEpisode");
+
+		// No Episode row for the subagent.
+		const episode = raw
+			?.prepare("SELECT * FROM graph_nodes WHERE kind = 'Episode' AND captured_by_session_id = ?")
+			.get("sub-1");
+		expect(episode ?? null).toBeNull();
+
+		// Subagent drift does NOT feed back into the primary drift-chain
+		// history — only primary Stop writes a closing 'drift' row.
+		const driftRows = raw
+			?.prepare(
+				"SELECT COUNT(*) as cnt FROM nous_history WHERE session_id = ? AND event_type = 'drift'",
+			)
+			.get("sub-1") as { cnt: number };
+		// One pre-seeded stale drift + one recompute = 2; no Stop-close drift.
+		expect(driftRows.cnt).toBe(2);
+	});
+
+	// ------------------------------------------------------------------
+	// (c) Drift recompute failure → logged to stderr, Stop hook continues.
+	//     We simulate failure by passing a session id that doesn't exist
+	//     (and by closing the DB for the "throw" path) — the function must
+	//     never throw, and writeEpisode must still run.
+	// ------------------------------------------------------------------
+	it("drift recompute on missing session returns no-op instead of throwing", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-missing", tmpDir);
+
+		const result = await recomputeDriftIfStale(db, "nonexistent-session", DEFAULT_NOUS_CONFIG);
+		expect(result.recomputed).toBe(false);
+		expect(result.reason).toBe("session-not-found");
+	});
+
+	it("drift recompute wrapped in try/catch in Stop hook: writeEpisode still runs if recompute throws", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-resilient", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+		seedSession(db, "resilient-1", "primary", 0.1, now);
+
+		// Simulate the Stop-hook flow with a forced-throw recompute helper.
+		let stderrCapture = "";
+		const fakeRecompute = async (): Promise<never> => {
+			throw new Error("simulated drift recompute failure");
+		};
+		try {
+			await fakeRecompute();
+		} catch (driftErr) {
+			stderrCapture = `[Nous] drift recompute failed (non-fatal): ${driftErr}\n`;
+		}
+
+		// writeEpisode must still run after a simulated recompute failure.
+		await writeEpisode(db, "resilient-1");
+		const raw = db.rawSqlite();
+		const episode = raw
+			?.prepare("SELECT * FROM graph_nodes WHERE kind = 'Episode' AND captured_by_session_id = ?")
+			.get("resilient-1");
+		expect(episode ?? null).not.toBeNull();
+		expect(stderrCapture).toContain("drift recompute failed");
+	});
+
+	// ------------------------------------------------------------------
+	// (d) Drift not stale → skip recompute.
+	// ------------------------------------------------------------------
+	it("skips recompute when the last drift event is still fresh and no new signals have fired", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-fresh", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+		seedSession(db, "fresh-1", "primary", 0.15, now);
+
+		// Fresh drift event, well within the staleness window.
+		appendHistory(db, {
+			session_id: "fresh-1",
+			event_type: "drift",
+			score: 0.15,
+			created_at: now - 10,
+		});
+
+		const before = getSession(db, "fresh-1");
+		expect(before?.state.driftScore).toBeCloseTo(0.15, 5);
+
+		const result = await recomputeDriftIfStale(db, "fresh-1", DEFAULT_NOUS_CONFIG, now);
+		expect(result.recomputed).toBe(false);
+		expect(result.reason).toBe("fresh");
+		expect(result.driftScore).toBeCloseTo(0.15, 5);
+
+		// Session state untouched.
+		const after = getSession(db, "fresh-1");
+		expect(after?.state.driftScore).toBeCloseTo(0.15, 5);
+	});
+
+	it("recomputes when fresh drift exists but new signals were written afterwards", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-signals", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+		seedSession(db, "sig-1", "primary", 0.1, now);
+
+		// Drift anchor is fresh (within window) ...
+		appendHistory(db, {
+			session_id: "sig-1",
+			event_type: "drift",
+			score: 0.1,
+			created_at: now - 20,
+		});
+		// ... but a burst of discomfort signals arrived AFTER the anchor.
+		for (let i = 0; i < 4; i++) {
+			appendHistory(db, {
+				session_id: "sig-1",
+				event_type: "discomfort",
+				score: 0.95,
+				created_at: now - i,
+			});
+		}
+
+		const result = await recomputeDriftIfStale(db, "sig-1", DEFAULT_NOUS_CONFIG, now);
+		expect(result.recomputed).toBe(true);
+		expect(result.reason).toBe("signals-since-last-drift");
+		expect(result.driftScore).toBeGreaterThan(0.9);
+	});
+
+	it("recomputes when no prior drift event exists for the session", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-noanchor", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+		seedSession(db, "anchorless-1", "primary", 0.0, now);
+		for (let i = 0; i < 3; i++) {
+			appendHistory(db, {
+				session_id: "anchorless-1",
+				event_type: "discomfort",
+				score: 0.8,
+				created_at: now - i,
+			});
+		}
+
+		const result = await recomputeDriftIfStale(db, "anchorless-1", DEFAULT_NOUS_CONFIG, now);
+		expect(result.recomputed).toBe(true);
+		expect(result.reason).toBe("no-prior-drift");
+		expect(result.driftScore).toBeCloseTo(0.8, 1);
+	});
+
+	it("is a no-op when config.enabled is false", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-disabled", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+		seedSession(db, "disabled-1", "primary", 0.1, now);
+
+		const result = await recomputeDriftIfStale(
+			db,
+			"disabled-1",
+			{ ...DEFAULT_NOUS_CONFIG, enabled: false },
+			now,
+		);
+		expect(result.recomputed).toBe(false);
+		expect(result.reason).toBe("disabled");
+	});
+
+	// ------------------------------------------------------------------
+	// (e) Contract: recomputeDriftIfStale never throws. Even when the DB
+	//     is closed mid-call, the function must return a safe no-op and
+	//     emit a stderr line so the Stop hook can still call writeEpisode.
+	// ------------------------------------------------------------------
+	it("never throws on internal error — logs to stderr and returns safe no-op", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-throw", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+		seedSession(db, "throw-1", "primary", 0.1, now);
+
+		// Capture stderr writes for assertion.
+		const stderrChunks: string[] = [];
+		const origWrite = process.stderr.write.bind(process.stderr);
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderrChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		}) as typeof process.stderr.write;
+
+		try {
+			// Close the DB to force every subsequent prepare/get/run to throw.
+			await db.close();
+			db = undefined;
+
+			// Must not throw.
+			const result = await recomputeDriftIfStale(
+				{
+					// Minimal SiaDb-shaped stub whose rawSqlite() returns an
+					// object that throws on .prepare — guaranteed internal error.
+					rawSqlite: () => ({
+						prepare: () => {
+							throw new Error("simulated db failure");
+						},
+					}),
+				} as unknown as SiaDb,
+				"throw-1",
+				DEFAULT_NOUS_CONFIG,
+				now,
+			);
+
+			expect(result.recomputed).toBe(false);
+			expect(result.driftScore).toBe(0);
+			expect(result.reason).toBe("session-not-found");
+			const combined = stderrChunks.join("");
+			expect(combined).toContain("recomputeDriftIfStale failed (non-fatal)");
+			expect(combined).toContain("simulated db failure");
+		} finally {
+			process.stderr.write = origWrite;
+		}
+	});
+
+	// ------------------------------------------------------------------
+	// (f) Cross-session signal isolation. Multi-agent scenario: session A
+	//     has discomfort signals written after its drift anchor; session B
+	//     shares the same wall-clock window but has no signals of its own.
+	//     Recompute must fire for A but NOT for B.
+	// ------------------------------------------------------------------
+	it("scopes signals-since-last-drift to the current session (no cross-session leakage)", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("test-stopext-scoped-signals", tmpDir);
+
+		const now = Math.floor(Date.now() / 1000);
+
+		// Both sessions share the same drift anchor timestamp so only
+		// the session_id predicate can distinguish them.
+		const anchor = now - 30;
+		seedSession(db, "sess-A", "primary", 0.1, now);
+		seedSession(db, "sess-B", "primary", 0.1, now);
+
+		appendHistory(db, {
+			session_id: "sess-A",
+			event_type: "drift",
+			score: 0.1,
+			created_at: anchor,
+		});
+		appendHistory(db, {
+			session_id: "sess-B",
+			event_type: "drift",
+			score: 0.1,
+			created_at: anchor,
+		});
+
+		// Only session A has post-anchor discomfort signals.
+		for (let i = 0; i < 3; i++) {
+			appendHistory(db, {
+				session_id: "sess-A",
+				event_type: "discomfort",
+				score: 0.9,
+				created_at: anchor + 1 + i,
+			});
+		}
+
+		const resultA = await recomputeDriftIfStale(db, "sess-A", DEFAULT_NOUS_CONFIG, now);
+		expect(resultA.recomputed).toBe(true);
+		expect(resultA.reason).toBe("signals-since-last-drift");
+
+		// Session B has no post-anchor signals of its own — the old
+		// unscoped query would have seen A's signals and (incorrectly)
+		// fired a recompute here. With the session_id predicate, B is
+		// correctly classified as "fresh".
+		const resultB = await recomputeDriftIfStale(db, "sess-B", DEFAULT_NOUS_CONFIG, now);
+		expect(resultB.recomputed).toBe(false);
+		expect(resultB.reason).toBe("fresh");
+	});
+});


### PR DESCRIPTION
## Summary

- New `recomputeDriftIfStale(db, sessionId, config, now?)` in `src/nous/self-monitor.ts` + exported `DRIFT_STALENESS_SECONDS = 120`. Catches missing anchor, stale age, or post-anchor signals (session-scoped — no cross-session leakage).
- `episode-writer.ts` writes `SubagentEpisode` node kind when `session_type = 'subagent'` (instead of skipping subagents entirely).
- `plugin-stop.ts` calls `recomputeDriftIfStale` before `writeEpisode` in its own try/catch.
- `SubagentEpisode` added to `NOUS_BOOKKEEPING_KINDS` so curiosity/retrieval skips it.
- No migration added: `graph_nodes.kind` is plain TEXT with no CHECK constraint.

Closes Phase 4 §Stop gap.

## Test plan

- [x] 10 new tests in `tests/unit/nous/stop-extensions.test.ts` (added 2 after reviewer findings: never-throws under internal error, session-scoped signals query)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` 2048/2049 pass (only pre-existing `isWorktree` failure)
- [x] `bash scripts/validate-plugin.sh` 9/9