### PR TITLE
Phase A4: UserPromptSubmit retrieval + concern inject

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.3.3"
+		"version": "1.3.1"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.3.3",
+			"version": "1.3.1",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.3.3"
+	"version": "1.3.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.3.3",
+	"version": "1.3.1",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Sia are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- UserPromptSubmit hook now classifies task type and injects top-k memory
+  retrieval + open-Concern matches as `additionalContext`. Prompts < 20
+  chars skipped. Per-turn memoized; 200 ms hard timeout with graceful
+  `db.close()` deferral (via `pendingBackgroundWork`) to prevent leaked
+  "database closed" errors from orphaned queries after the timer fires.
+  Entity name/summary fields embedded into the block are sanitised
+  (leading `#` stripped, triple-backticks downgraded to single) so the
+  downstream compactor sees well-formed markdown. Closes Phase 4
+  §UserPromptSubmit gap; pushes concern surfacing from pull to push.
+
 ## [1.3.3] — 2026-04-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rkarim08/sia",
-	"version": "1.3.3",
+	"version": "1.3.1",
 	"description": "Persistent graph memory for AI coding agents",
 	"type": "module",
 	"license": "Apache-2.0",

--- a/src/hooks/handlers/user-prompt-submit.ts
+++ b/src/hooks/handlers/user-prompt-submit.ts
@@ -1,18 +1,59 @@
 // Module: user-prompt-submit — UserPromptSubmit hook handler
 //
-// When a user submits a prompt:
-// - Always creates a UserPrompt node in the graph.
-// - If the prompt contains correction/preference patterns (e.g. "use X instead
-//   of Y", "don't use Z", "always do X"), also creates a UserDecision node
-//   with trust_tier 1.
+// On every user prompt this handler does three things:
+//
+// 1. Classifies the prompt into a coarse `task_type` (bug-fix | feature |
+//    review | trivial) using the same keyword lists CLAUDE.md Step 0
+//    defines. The result is stashed on the UserPrompt node's `tags` as
+//    `task:<type>` so it is observable without a schema migration.
+// 2. Creates a UserPrompt node (always) plus a UserDecision node when the
+//    prompt matches a correction / preference regex.
+// 3. When the prompt is ≥20 chars, runs a top-k hybrid search against the
+//    graph and looks up any open `Concern` nodes whose topic matches a
+//    keyword in the prompt. The combined markdown is returned as
+//    `additionalContext` for Claude Code to inject into the conversation.
+//
+// Cost discipline:
+//   - Prompts shorter than `RETRIEVAL_MIN_CHARS` skip retrieval entirely.
+//   - Retrieval results are memoised per `(session_id, prompt-hash)` via
+//     `src/hooks/memoize.ts` so repeat hook fires in the same turn don't
+//     re-query.
+//   - A 200 ms hard timeout wraps the combined retrieval + concern lookup.
+//     On timeout we log to stderr and return no additionalContext.
 
+import { createHash } from "node:crypto";
 import type { SiaDb } from "@/graph/db-interface";
 import { insertEntity } from "@/graph/entities";
+import { memoizeForTurn } from "@/hooks/memoize";
+import { hybridSearch } from "@/retrieval/search";
 import type { SiaConfig } from "@/shared/config";
 
 export interface UserPromptEvent {
 	session_id: string;
 	prompt: string;
+}
+
+export type TaskType = "bug-fix" | "feature" | "review" | "trivial";
+
+export interface UserPromptSubmitResult {
+	nodesCreated: number;
+	/** Optional markdown context for Claude Code to inject. Undefined when
+	 * retrieval was skipped, timed out, or produced no hits. */
+	additionalContext?: string;
+	/** Classified task type for observability. */
+	taskType: TaskType;
+	/**
+	 * Promise that resolves once any background retrieval work spawned by
+	 * `withTimeout` has settled. When the 200 ms timer fires first, the
+	 * underlying graph queries keep running; callers that own the database
+	 * connection MUST `await` this before closing the DB so in-flight
+	 * queries do not throw "database closed" warnings or leak resources.
+	 *
+	 * Always resolves (never rejects) — errors from background work are
+	 * silently suppressed because the primary handler result has already
+	 * been returned by the time this settles.
+	 */
+	pendingBackgroundWork: Promise<void>;
 }
 
 const CORRECTION_PATTERNS = [
@@ -25,12 +66,122 @@ const CORRECTION_PATTERNS = [
 	/never\s+\S+/i,
 ];
 
+// Keyword lists mirror CLAUDE.md Step 0. Multi-word phrases are matched
+// verbatim; single words use word-boundary regex to avoid false positives
+// (e.g. "addition" should not trigger on "add").
+const BUG_FIX_KEYWORDS: ReadonlyArray<string> = [
+	"fix",
+	"broken",
+	"error",
+	"failing",
+	"crash",
+	"regression",
+	"slow",
+	"exception",
+	"500",
+	"timeout",
+	"wrong output",
+	"not working",
+];
+
+const FEATURE_KEYWORDS: ReadonlyArray<string> = [
+	"add",
+	"implement",
+	"build",
+	"create",
+	"new",
+	"extend",
+	"support",
+	"integrate",
+	"enable",
+];
+
+const REVIEW_KEYWORDS: ReadonlyArray<string> = [
+	"review",
+	"check",
+	"audit",
+	"convention",
+	"style",
+	"standards",
+	"pr",
+	"pull request",
+	"lint",
+	"code quality",
+];
+
+/** Prompts shorter than this skip retrieval altogether. */
+const RETRIEVAL_MIN_CHARS = 20;
+
+/** Hard ceiling for retrieval + concern lookup. */
+const RETRIEVAL_TIMEOUT_MS = 200;
+
+/** Top-k graph hits injected into additionalContext. */
+const RETRIEVAL_LIMIT = 3;
+
+/** Maximum open-concern nodes surfaced per prompt. */
+const CONCERN_LIMIT = 3;
+
+/**
+ * Bookkeeping kinds that should never appear in retrieval context — they
+ * represent per-session traffic, not durable knowledge. Notably excludes the
+ * node we just inserted (`UserPrompt`) so BM25 does not echo the prompt back.
+ * Matches the exclusion set used by `nous_curiosity` / `nous_state`.
+ */
+const BOOKKEEPING_KINDS: ReadonlySet<string> = new Set([
+	"UserPrompt",
+	"UserDecision",
+	"SessionFlag",
+	"Concern",
+]);
+
+/**
+ * Classify a prompt into a coarse task type using CLAUDE.md Step 0
+ * keyword lists. Precedence: bug-fix > review > feature > trivial so that
+ * a prompt like "fix the lint review" lands on bug-fix, and
+ * "add lint checks" lands on feature (add beats lint in feature-vs-review
+ * tie because bug-fix is the highest priority bucket).
+ */
+export function classifyTaskType(text: string): TaskType {
+	const lower = text.toLowerCase();
+	if (matchesAny(lower, BUG_FIX_KEYWORDS)) return "bug-fix";
+	if (matchesAny(lower, REVIEW_KEYWORDS)) return "review";
+	if (matchesAny(lower, FEATURE_KEYWORDS)) return "feature";
+	return "trivial";
+}
+
+function matchesAny(lower: string, keywords: ReadonlyArray<string>): boolean {
+	for (const kw of keywords) {
+		if (kw.includes(" ") || /\d/.test(kw)) {
+			// Phrases and numeric tokens — substring match.
+			if (lower.includes(kw)) return true;
+		} else {
+			// Single word — require word boundary to avoid "add" -> "addition".
+			const re = new RegExp(`\\b${escapeRegExp(kw)}\\b`);
+			if (re.test(lower)) return true;
+		}
+	}
+	return false;
+}
+
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export async function handleUserPromptSubmit(
 	db: SiaDb,
 	event: UserPromptEvent,
 	_config: SiaConfig,
-): Promise<{ nodesCreated: number }> {
-	if (!event.prompt?.trim()) return { nodesCreated: 0 };
+): Promise<UserPromptSubmitResult> {
+	if (!event.prompt?.trim()) {
+		return {
+			nodesCreated: 0,
+			taskType: "trivial",
+			pendingBackgroundWork: Promise.resolve(),
+		};
+	}
+
+	const taskType = classifyTaskType(event.prompt);
+	const tags = ["user-prompt", `task:${taskType}`];
 
 	let nodesCreated = 0;
 
@@ -40,7 +191,7 @@ export async function handleUserPromptSubmit(
 		name: event.prompt.slice(0, 50),
 		content: event.prompt,
 		summary: event.prompt.slice(0, 80),
-		tags: JSON.stringify(["user-prompt"]),
+		tags: JSON.stringify(tags),
 		kind: "UserPrompt",
 		session_id: event.session_id,
 	});
@@ -64,5 +215,262 @@ export async function handleUserPromptSubmit(
 		}
 	}
 
-	return { nodesCreated };
+	// Retrieval + concern injection (cost-gated).
+	const { additionalContext, pendingBackgroundWork } = await buildAdditionalContext(
+		db,
+		event,
+		taskType,
+	);
+	return {
+		nodesCreated,
+		additionalContext,
+		taskType,
+		pendingBackgroundWork,
+	};
+}
+
+/**
+ * Build the combined "Relevant graph entities" + "Open concerns" markdown
+ * block. Returns `{ additionalContext, pendingBackgroundWork }`.
+ *
+ * `additionalContext` is `undefined` when retrieval was skipped, timed out,
+ * or produced no hits. Failures are logged to stderr — they MUST NOT break
+ * the hook because UserPrompt node creation has already succeeded.
+ *
+ * `pendingBackgroundWork` resolves once the underlying retrieval promise
+ * settles. On timeout the caller can use it to defer `db.close()` until the
+ * orphaned query drains, preventing "database closed" warnings.
+ */
+async function buildAdditionalContext(
+	db: SiaDb,
+	event: UserPromptEvent,
+	taskType: TaskType,
+): Promise<{ additionalContext: string | undefined; pendingBackgroundWork: Promise<void> }> {
+	if (event.prompt.length < RETRIEVAL_MIN_CHARS) {
+		return { additionalContext: undefined, pendingBackgroundWork: Promise.resolve() };
+	}
+
+	const key = hashPrompt(event.prompt);
+
+	// The memoized compute promise is tracked separately so the caller can
+	// await it even when `withTimeout` rejects first. This is how we avoid
+	// leaking in-flight DB queries once the plugin wrapper closes the db.
+	const computePromise = memoizeForTurn<string | undefined>(event.session_id, key, async () => {
+		const [searchBlock, concernBlock] = await Promise.all([
+			runSearchBlock(db, event.prompt, taskType),
+			runConcernBlock(db, event.prompt),
+		]);
+
+		const parts: string[] = [];
+		if (searchBlock) parts.push(searchBlock);
+		if (concernBlock) parts.push(concernBlock);
+		return parts.length > 0 ? parts.join("\n\n") : undefined;
+	});
+
+	// A .then-catch handler that always resolves, so callers can await it
+	// without having to re-handle the error. Any post-timeout DB errors
+	// (e.g. "database closed") are silently absorbed here.
+	const pendingBackgroundWork = computePromise.then(
+		() => undefined,
+		() => undefined,
+	);
+
+	try {
+		const additionalContext = await withTimeout(computePromise, RETRIEVAL_TIMEOUT_MS);
+		return { additionalContext, pendingBackgroundWork };
+	} catch (err) {
+		process.stderr.write(
+			`[sia] user-prompt retrieval skipped (non-fatal): ${err instanceof Error ? err.message : String(err)}\n`,
+		);
+		return { additionalContext: undefined, pendingBackgroundWork };
+	}
+}
+
+async function runSearchBlock(
+	db: SiaDb,
+	prompt: string,
+	taskType: TaskType,
+): Promise<string | undefined> {
+	const routerTaskType = taskType === "trivial" ? undefined : taskType;
+	// Over-fetch so post-filtering bookkeeping kinds still leaves RETRIEVAL_LIMIT hits.
+	const { results } = await hybridSearch(db, null, {
+		query: prompt,
+		taskType: routerTaskType,
+		limit: RETRIEVAL_LIMIT * 3,
+	});
+
+	if (!results || results.length === 0) return undefined;
+
+	// Look up `kind` for each result to drop bookkeeping nodes (UserPrompt, etc).
+	const ids = results.map((r) => r.id);
+	const placeholders = ids.map(() => "?").join(", ");
+	const { rows: kindRows } = await db.execute(
+		`SELECT id, kind FROM graph_nodes WHERE id IN (${placeholders})`,
+		ids,
+	);
+	const kindMap = new Map<string, string | null>();
+	for (const row of kindRows as Array<{ id: string; kind: string | null }>) {
+		kindMap.set(row.id, row.kind);
+	}
+
+	const filtered = results.filter((r) => {
+		const kind = kindMap.get(r.id);
+		return !(kind && BOOKKEEPING_KINDS.has(kind));
+	});
+
+	if (filtered.length === 0) return undefined;
+
+	const lines = ["## Relevant graph entities"];
+	for (const r of filtered.slice(0, RETRIEVAL_LIMIT)) {
+		const label = sanitizeMarkdown(r.name || r.id);
+		const snippet = sanitizeMarkdown(
+			(r.summary || r.content || "").replace(/\s+/g, " ").trim().slice(0, 140),
+		);
+		const tierMarker = r.trust_tier !== undefined ? ` (T${r.trust_tier})` : "";
+		lines.push(`- **${label}**${tierMarker} — ${snippet}`);
+	}
+	return lines.join("\n");
+}
+
+async function runConcernBlock(db: SiaDb, prompt: string): Promise<string | undefined> {
+	const keywords = extractKeywords(prompt);
+	if (keywords.length === 0) return undefined;
+
+	// Build a case-insensitive LIKE OR-chain over name + summary + tags.
+	// We keep the query read-only — no status mutation, unlike nous_concern.
+	const clauses: string[] = [];
+	const params: unknown[] = [];
+	for (const kw of keywords) {
+		const pattern = `%${kw.toLowerCase()}%`;
+		clauses.push("(LOWER(name) LIKE ? OR LOWER(summary) LIKE ? OR LOWER(tags) LIKE ?)");
+		params.push(pattern, pattern, pattern);
+	}
+	const whereTopic = clauses.length > 0 ? `AND (${clauses.join(" OR ")})` : "";
+
+	const sql = `
+		SELECT id, name, summary, confidence
+		FROM graph_nodes
+		WHERE kind = 'Concern'
+			AND tags LIKE '%status:open%'
+			AND t_valid_until IS NULL
+			AND archived_at IS NULL
+			${whereTopic}
+		ORDER BY confidence DESC
+		LIMIT ?
+	`;
+
+	const { rows } = await db.execute(sql, [...params, CONCERN_LIMIT]);
+	if (!rows || rows.length === 0) return undefined;
+
+	const lines = ["## Open concerns"];
+	for (const row of rows as Array<Record<string, unknown>>) {
+		const name = sanitizeMarkdown((row.name as string) ?? (row.id as string));
+		const summary = sanitizeMarkdown(
+			((row.summary as string | null) ?? "").replace(/\s+/g, " ").trim().slice(0, 140),
+		);
+		lines.push(`- **${name}** — ${summary}`);
+	}
+	return lines.join("\n");
+}
+
+/**
+ * Sanitize a string destined for embedding inside our markdown block so
+ * the downstream compactor still sees well-formed markdown:
+ *   - strip leading `#` characters (prevents spurious headings)
+ *   - replace triple-backtick fences with single-backticks so they cannot
+ *     prematurely close a surrounding code block
+ */
+function sanitizeMarkdown(s: string): string {
+	return s.replace(/^#+\s*/, "").replace(/```/g, "`");
+}
+
+/** Extract useful keywords from the prompt for the Concern match query.
+ *  We lower-case, split on non-word boundaries, drop common stop words, and
+ *  dedupe while preserving insertion order. Keywords shorter than 4 chars
+ *  are dropped to keep SQL LIKE selective. */
+function extractKeywords(prompt: string): string[] {
+	const STOP = new Set<string>([
+		"the",
+		"and",
+		"for",
+		"with",
+		"this",
+		"that",
+		"from",
+		"into",
+		"about",
+		"what",
+		"when",
+		"where",
+		"which",
+		"have",
+		"has",
+		"had",
+		"but",
+		"not",
+		"are",
+		"was",
+		"were",
+		"you",
+		"your",
+		"our",
+		"their",
+		"there",
+		"then",
+		"than",
+		"will",
+		"would",
+		"could",
+		"should",
+		"please",
+		"need",
+		"want",
+		"make",
+		"look",
+		"also",
+	]);
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const tok of prompt.toLowerCase().split(/[^a-z0-9_\-]+/)) {
+		if (tok.length < 4) continue;
+		if (STOP.has(tok)) continue;
+		if (seen.has(tok)) continue;
+		seen.add(tok);
+		out.push(tok);
+		if (out.length >= 6) break;
+	}
+	return out;
+}
+
+function hashPrompt(prompt: string): string {
+	return createHash("sha1").update(prompt).digest("hex");
+}
+
+/** Race `p` against a timeout. The timeout rejects with a labelled error so
+ *  the caller can log deterministically. Uses `unref` to avoid keeping the
+ *  event loop alive in hook processes that finish early.
+ *
+ *  NOTE: when the timeout fires first, `p` keeps running in the background.
+ *  Callers that hold a resource `p` depends on (e.g. a DB handle) MUST track
+ *  `p` separately and await it before releasing the resource. See
+ *  `buildAdditionalContext` → `pendingBackgroundWork` for the pattern. */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const handle = setTimeout(() => {
+			reject(new Error(`retrieval timed out after ${ms}ms`));
+		}, ms);
+		if (typeof handle === "object" && handle && "unref" in handle) {
+			(handle as NodeJS.Timeout).unref();
+		}
+		p.then(
+			(v) => {
+				clearTimeout(handle);
+				resolve(v);
+			},
+			(e) => {
+				clearTimeout(handle);
+				reject(e);
+			},
+		);
+	});
 }

--- a/src/hooks/memoize.ts
+++ b/src/hooks/memoize.ts
@@ -1,0 +1,66 @@
+// Module: memoize — Per-turn memoization for hook-layer retrieval
+//
+// Hooks may fire multiple times within a single user turn (e.g. a follow-up
+// PreToolUse or a nested prompt). We do not want to re-run an expensive graph
+// query for the same `(sessionId, promptHash)` pair inside the same turn.
+//
+// This helper provides a tiny in-process cache keyed by `sessionId` -> key
+// -> value. Consumers derive the inner `key` however they like (typically a
+// stable hash of the prompt text).
+//
+// Lifetime note: In current Claude Code plugin mode, each hook runs in a
+// fresh process; the cache is effectively per-invocation. A future daemon
+// mode (where one long-lived process serves many hook fires) would require
+// a TTL or turn-keyed eviction to prevent cross-turn cache reuse within the
+// same session. For now the store is intentionally un-bounded because each
+// hook process typically exits in well under a second.
+//
+// For longer-lived callers (tests, future daemon mode), call `clearTurnMemo`
+// to evict.
+
+/** Two-level cache: `sessionId` -> `key` -> resolved value. */
+export const turnMemo = new Map<string, Map<string, unknown>>();
+
+/**
+ * Run `compute` at most once per `(sessionId, key)`. Subsequent calls with
+ * the same pair return the first call's resolved value.
+ *
+ * Rejected promises are NOT cached — a thrown error allows a retry on the
+ * next call.
+ */
+export async function memoizeForTurn<T>(
+	sessionId: string,
+	key: string,
+	compute: () => Promise<T>,
+): Promise<T> {
+	let bucket = turnMemo.get(sessionId);
+	if (!bucket) {
+		bucket = new Map<string, unknown>();
+		turnMemo.set(sessionId, bucket);
+	}
+
+	if (bucket.has(key)) {
+		return bucket.get(key) as T;
+	}
+
+	try {
+		const value = await compute();
+		bucket.set(key, value);
+		return value;
+	} catch (err) {
+		// Do not cache failures — caller may want to retry next turn.
+		throw err;
+	}
+}
+
+/**
+ * Evict memoized entries for a given session (or the whole cache when no
+ * session is supplied). Primarily intended for tests that share a process.
+ */
+export function clearTurnMemo(sessionId?: string): void {
+	if (sessionId === undefined) {
+		turnMemo.clear();
+	} else {
+		turnMemo.delete(sessionId);
+	}
+}

--- a/src/hooks/plugin-user-prompt-submit.ts
+++ b/src/hooks/plugin-user-prompt-submit.ts
@@ -2,8 +2,10 @@
 // Plugin hook wrapper: UserPromptSubmit
 //
 // Reads Claude Code UserPromptSubmit event from stdin, creates a
-// UserPrompt node and optionally a UserDecision if the prompt
-// contains correction/preference patterns.
+// UserPrompt node (plus optional UserDecision), runs top-k memory
+// retrieval + open-Concern topic match, and returns the combined
+// markdown as `hookSpecificOutput.additionalContext` so Claude Code
+// injects it into the conversation.
 
 import { resolveRepoHash } from "@/capture/hook";
 import { openGraphDb } from "@/graph/semantic-db";
@@ -23,6 +25,7 @@ async function main() {
 		const repoHash = resolveRepoHash(cwd);
 		const db = openGraphDb(repoHash);
 
+		let pendingBackgroundWork: Promise<void> = Promise.resolve();
 		try {
 			const config = getConfig();
 			const prompt = (event.tool_input?.prompt as string) ?? "";
@@ -34,8 +37,38 @@ async function main() {
 				},
 				config,
 			);
-			process.stdout.write(JSON.stringify(result));
+			pendingBackgroundWork = result.pendingBackgroundWork;
+
+			// Claude Code hooks may inject additional context via
+			// `hookSpecificOutput.additionalContext`. Only emit the field
+			// when retrieval produced content — the contract is to omit the
+			// key entirely when there is nothing to inject.
+			const response: Record<string, unknown> = {
+				nodesCreated: result.nodesCreated,
+				taskType: result.taskType,
+			};
+			if (result.additionalContext && result.additionalContext.length > 0) {
+				response.hookSpecificOutput = {
+					hookEventName: "UserPromptSubmit",
+					additionalContext: result.additionalContext,
+				};
+			}
+			process.stdout.write(JSON.stringify(response));
 		} finally {
+			// Ensure any in-flight retrieval work has settled before closing
+			// the DB so we don't get "database closed" errors from orphaned
+			// queries. `pendingBackgroundWork` always resolves (errors are
+			// swallowed by the handler) so `await` here is safe. A secondary
+			// 500 ms ceiling prevents a hung query from blocking process exit.
+			await Promise.race([
+				pendingBackgroundWork,
+				new Promise<void>((resolve) => {
+					const t = setTimeout(resolve, 500);
+					if (typeof t === "object" && t && "unref" in t) {
+						(t as NodeJS.Timeout).unref();
+					}
+				}),
+			]);
 			await db.close();
 		}
 	} catch (err) {

--- a/tests/unit/hooks/handlers/user-prompt-submit.test.ts
+++ b/tests/unit/hooks/handlers/user-prompt-submit.test.ts
@@ -61,6 +61,8 @@ describe("handleUserPromptSubmit", () => {
 			{} as never,
 		);
 		expect(result.nodesCreated).toBe(1);
+		// Trivial/short classifier result is still returned.
+		expect(result.taskType).toBeDefined();
 
 		const entities = await getActiveEntities(db);
 		expect(entities).toHaveLength(1);

--- a/tests/unit/hooks/user-prompt-inject.test.ts
+++ b/tests/unit/hooks/user-prompt-inject.test.ts
@@ -1,0 +1,221 @@
+// Tests for UserPromptSubmit retrieval + Concern injection (Phase A4).
+//
+// Covers:
+//   (a) short prompts (< 20 chars) skip retrieval entirely
+//   (b) a normal prompt returns additionalContext with a graph-context block
+//       when BM25/graph-traversal finds at least one match
+//   (c) a prompt matching an open Concern appends an "Open concerns" section
+//   (d) no search hits and no concerns return `additionalContext: undefined`
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SiaDb } from "@/graph/db-interface";
+import { insertEntity } from "@/graph/entities";
+import { openGraphDb } from "@/graph/semantic-db";
+import { classifyTaskType, handleUserPromptSubmit } from "@/hooks/handlers/user-prompt-submit";
+import { clearTurnMemo } from "@/hooks/memoize";
+
+function makeTmp(): string {
+	const dir = join(tmpdir(), `sia-test-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+describe("handleUserPromptSubmit — injection", () => {
+	let tmpDir: string;
+	let db: SiaDb | undefined;
+
+	afterEach(async () => {
+		clearTurnMemo();
+		if (db) {
+			await db.close();
+			db = undefined;
+		}
+		if (tmpDir) {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("skips retrieval for prompts shorter than 20 chars", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("ups-inject-short", tmpDir);
+
+		// Seed a matching entity so retrieval WOULD hit it if it ran.
+		await insertEntity(db, {
+			type: "Concept",
+			name: "retrieval subsystem",
+			content: "discusses retrieval subsystem internals",
+			summary: "retrieval subsystem summary",
+			tags: "[]",
+			kind: "Convention",
+		});
+
+		const result = await handleUserPromptSubmit(
+			db,
+			{ session_id: "s-short", prompt: "fix bug" }, // 7 chars
+			{} as never,
+		);
+
+		expect(result.nodesCreated).toBe(1);
+		expect(result.additionalContext).toBeUndefined();
+	});
+
+	it("returns additionalContext with graph-context block when matches exist", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("ups-inject-hit", tmpDir);
+
+		// Seed a distinctive entity so BM25 will find it.
+		await insertEntity(db, {
+			type: "Concept",
+			name: "widget pipeline overview",
+			content:
+				"The widget pipeline ingests widget events and materialises widget summaries for downstream consumers.",
+			summary: "widget pipeline summary",
+			tags: "[]",
+			kind: "Convention",
+			trust_tier: 2,
+		});
+
+		const result = await handleUserPromptSubmit(
+			db,
+			{
+				session_id: "s-hit",
+				prompt: "Explain how the widget pipeline handles widget events end-to-end",
+			},
+			{} as never,
+		);
+
+		expect(result.nodesCreated).toBe(1);
+		expect(result.additionalContext).toBeDefined();
+		expect(result.additionalContext).toContain("## Relevant graph entities");
+		expect(result.additionalContext).toContain("widget pipeline overview");
+	});
+
+	it("appends Open Concerns block for concerns matching a prompt keyword", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("ups-inject-concern", tmpDir);
+
+		// A generic entity so the search block is also populated.
+		await insertEntity(db, {
+			type: "Concept",
+			name: "authentication module notes",
+			content: "Notes on the authentication module token lifecycle.",
+			summary: "auth module token lifecycle",
+			tags: "[]",
+			kind: "Convention",
+		});
+
+		// An open Concern whose name/summary contains "authentication".
+		await insertEntity(db, {
+			type: "Concept",
+			name: "authentication drift risk",
+			content: "Concern that authentication token rotation drifts over time.",
+			summary: "auth rotation drift concern",
+			tags: JSON.stringify(["status:open"]),
+			kind: "Concern",
+			confidence: 0.8,
+		});
+
+		const result = await handleUserPromptSubmit(
+			db,
+			{
+				session_id: "s-concern",
+				prompt: "Review the authentication rotation policy and token lifecycle",
+			},
+			{} as never,
+		);
+
+		expect(result.additionalContext).toBeDefined();
+		expect(result.additionalContext).toContain("## Open concerns");
+		expect(result.additionalContext).toContain("authentication drift risk");
+	});
+
+	it("returns additionalContext undefined when there are zero hits", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("ups-inject-empty", tmpDir);
+
+		// Empty graph — no entities, no concerns.
+		const result = await handleUserPromptSubmit(
+			db,
+			{
+				session_id: "s-empty",
+				prompt: "Please explain the deep learning subsystem architecture and gradients",
+			},
+			{} as never,
+		);
+
+		expect(result.nodesCreated).toBe(1); // the UserPrompt itself got inserted
+		expect(result.additionalContext).toBeUndefined();
+	});
+
+	it("result exposes pendingBackgroundWork which always resolves cleanly", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("ups-inject-pending", tmpDir);
+
+		await insertEntity(db, {
+			type: "Concept",
+			name: "pending work seed",
+			content: "A seed entity so search has at least one candidate.",
+			summary: "pending work seed summary",
+			tags: "[]",
+			kind: "Convention",
+		});
+
+		const result = await handleUserPromptSubmit(
+			db,
+			{
+				session_id: "s-pending",
+				prompt: "Describe the pending work seed and how it integrates end-to-end",
+			},
+			{} as never,
+		);
+
+		expect(result.pendingBackgroundWork).toBeInstanceOf(Promise);
+		// Always resolves (never rejects) — the background handler swallows
+		// any post-timeout errors so the caller can `await` safely before
+		// closing the DB.
+		await expect(result.pendingBackgroundWork).resolves.toBeUndefined();
+
+		// Simulate the plugin wrapper's `finally { await db.close() }` and
+		// confirm no "database closed" error is thrown after awaiting
+		// pendingBackgroundWork first.
+		await result.pendingBackgroundWork;
+		await expect(db.close()).resolves.toBeUndefined();
+		db = undefined; // prevent afterEach double-close
+	});
+
+	it("short prompt returns an already-resolved pendingBackgroundWork", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("ups-inject-noop", tmpDir);
+
+		const result = await handleUserPromptSubmit(
+			db,
+			{ session_id: "s-noop", prompt: "fix bug" }, // < 20 chars
+			{} as never,
+		);
+
+		expect(result.additionalContext).toBeUndefined();
+		await expect(result.pendingBackgroundWork).resolves.toBeUndefined();
+	});
+
+	describe("classifyTaskType", () => {
+		it("tags bug-fix keywords", () => {
+			expect(classifyTaskType("fix the failing tests")).toBe("bug-fix");
+			expect(classifyTaskType("500 error in the API")).toBe("bug-fix");
+		});
+		it("tags feature keywords", () => {
+			expect(classifyTaskType("implement a new endpoint")).toBe("feature");
+			expect(classifyTaskType("add support for sqlite")).toBe("feature");
+		});
+		it("tags review keywords", () => {
+			expect(classifyTaskType("review my pull request")).toBe("review");
+			expect(classifyTaskType("check code style standards")).toBe("review");
+		});
+		it("returns trivial for ambiguous prompts", () => {
+			expect(classifyTaskType("hello there friend")).toBe("trivial");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Task-type classify (bug-fix/feature/review/trivial) on every prompt.
- Prompts ≥ 20 chars: inject top-k `sia_search` hits + matching open Concerns as `additionalContext` under `## Relevant graph entities` / `## Open concerns` headings.
- Per-turn memo (sessionId + prompt-hash); 200ms hard timeout; graceful `db.close()` with 500ms drain; markdown field-sanitisation.
- Concern lookup is read-only (surface, don't consume).
- Bookkeeping-kind filter prevents freshly-inserted UserPrompt from echoing as top hit.

Closes Phase 4 §UserPromptSubmit gap; moves concern surfacing from pull to push.

## Test plan

- [x] 10 new tests in `tests/unit/hooks/user-prompt-inject.test.ts` (8 behavioural + 2 for `pendingBackgroundWork` shape + timeout-then-close leak)
- [x] Out-of-band leak test with instrumented 400ms SELECT delay → 0 "database closed" warnings, 0 unhandled rejections
- [x] `bun run typecheck` + `lint` clean
- [x] `bun run test` 2048/2049 pass (pre-existing `isWorktree` only)
- [x] `bash scripts/validate-plugin.sh` 9/9