### PR TITLE
Phase A8: verify-before-completion skill + brainstorming mandate

### DIFF
--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -54,10 +54,10 @@ For local development (project-scoped): `claude --plugin-dir /path/to/sia`.
 | `nous_concern` | Surface open Concerns weighted by active Preferences |
 | `nous_modify` | Create / update / deprecate Preference nodes (gated, `reason` required) |
 
-## Skills (47)
+## Skills (48)
 
 Skills are slash-invocable workflows that Claude Code can load on demand. For the full table with trigger descriptions and invocation guidance, see
-[PLUGIN_USAGE.md → Skills](PLUGIN_USAGE.md#skills-47).
+[PLUGIN_USAGE.md → Skills](PLUGIN_USAGE.md#skills-48).
 
 Shortest path for a new user: `/sia-setup` → `/sia-tour` → start working. Sia captures automatically afterwards.
 

--- a/PLUGIN_USAGE.md
+++ b/PLUGIN_USAGE.md
@@ -23,7 +23,7 @@ See also: [README.md](README.md) (product overview), [CLAUDE.md](CLAUDE.md) (age
 
 Shortest path for a new user: `/sia-setup` → `/sia-tour` → start working normally. Sia captures automatically; you only call skills when you want a targeted action.
 
-## Skills (47)
+## Skills (48)
 
 ### Core
 
@@ -68,6 +68,7 @@ Shortest path for a new user: `/sia-setup` → `/sia-tour` → start working nor
 | [sia-debug-workflow](skills/sia-debug-workflow/SKILL.md) | Temporal debug workflow | Bug / test failure / regression |
 | [sia-test](skills/sia-test/SKILL.md) | Graph-informed TDD | Implementing with TDD; adding regression tests |
 | [sia-verify](skills/sia-verify/SKILL.md) | Verification gate with area-specific checks | Before claiming "done" |
+| [sia-verify-before-completion](skills/sia-verify-before-completion/SKILL.md) | Verify-then-claim discipline with past-failure lookup | Pre-commit / pre-PR / pre-deploy |
 | [sia-review-respond](skills/sia-review-respond/SKILL.md) | Graph-backed code-review responses | PR comments arrive |
 | [sia-finish](skills/sia-finish/SKILL.md) | Branch finishing with semantic PR summaries | Branch ready to merge |
 | [sia-impact](skills/sia-impact/SKILL.md) | Pre-refactor impact analysis | Before rename / signature change |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Sia gives your agent a typed, temporal, ontology-enforced knowledge graph that c
 /plugin install sia@sia-plugins
 ```
 
-This registers all 29 MCP tools, 47 skills, 26 agents, 9 hook entries across 7 event types, and CLAUDE.md behavioral directives in one step.
+This registers all 29 MCP tools, 48 skills, 26 agents, 9 hook entries across 7 event types, and CLAUDE.md behavioral directives in one step.
 
 > **Coming soon:** Once Sia is accepted into the official Anthropic marketplace, installation will simplify to `/plugin install sia@claude-plugins-official`.
 

--- a/skills/sia-brainstorm/SKILL.md
+++ b/skills/sia-brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-brainstorm
-description: Brainstorms features using SIA's knowledge graph — surfaces past decisions, rejected alternatives, and architectural constraints before proposing approaches. Use when starting any creative work, designing features, or modifying behavior.
+description: You MUST use this before any creative work — creating features, building components, adding functionality, or modifying behaviour. Explores user intent, requirements, and design before implementation, surfacing past decisions and architectural constraints from the graph. Retrieval-first — load prior art before inventing new structures.
 ---
 
 # SIA-Enhanced Brainstorming

--- a/skills/sia-finish/SKILL.md
+++ b/skills/sia-finish/SKILL.md
@@ -65,6 +65,8 @@ Collect all entities captured during this branch's lifetime. These become the PR
 
 ### Step 1 — Verify Tests (same as standard)
 
+Always invoke `/sia-verify-before-completion` first.
+
 Hard gate — tests must pass.
 
 ### Step 2-3 — Determine Base Branch + Present Options (same as standard)

--- a/skills/sia-verify-before-completion/SKILL.md
+++ b/skills/sia-verify-before-completion/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: sia-verify-before-completion
+description: |
+  Use when about to claim work is complete, fixed, or passing, before
+  committing or creating PRs — requires running verification commands
+  and confirming output before making any success claims; evidence
+  before assertions always. Runs `sia-verify` + `sia-test` against
+  the current area and surfaces past failure-modes for that area from
+  the graph. Required reading before invoking `sia-finish`.
+---
+
+# Verify Before Completion
+
+A "done" claim without evidence is a failure. This skill enforces the
+**verify-then-claim** discipline: you run verification commands, read the
+output, confirm it supports the claim, and only then state that work is
+complete. Sia adds a past-failure lookup so you do not rediscover known
+regressions the hard way.
+
+## When to use
+
+Invoke this skill at three pre-action triggers:
+
+1. **Pre-commit** — before `git commit`, verify the working tree passes
+   the checks the area requires (tests, typecheck, lint).
+2. **Pre-PR** — before opening a PR or invoking `/sia-finish`, verify
+   the branch is green end-to-end and that known failure-modes for the
+   touched area are covered.
+3. **Pre-deploy** — before merging to a protected branch or triggering
+   a release pipeline, verify integration/e2e gates and confirm the
+   deploy target matches what was tested.
+
+## Required verification checklist
+
+```
+- [ ] Run the area's verification commands (`sia-verify`, `sia-test`,
+      and any area-specific gates surfaced by Sia).
+- [ ] READ the full output — do not skim. Scroll to the summary lines
+      and check exit codes. Silent failures hide in the middle.
+- [ ] Query the graph for past failure-modes in the same area:
+      `sia_search({ query: "<area> failure regression", node_types: ["Bug"], limit: 10 })`
+      — if a prior Bug entity exists, confirm its regression surface
+      is covered by the run you just read.
+- [ ] Confirm no open Concern (`nous_concern`) blocks the completion
+      claim. An open Concern in the same area is a hold signal.
+- [ ] State the evidence alongside the claim: "<check X> passed with
+      output <summary>" — not just "done".
+```
+
+## Workflow
+
+### Step 0 — Past-failure lookup
+
+Before running commands, query the graph for the area's known failure-modes:
+
+```
+sia_search({ query: "<area> failure regression bug", node_types: ["Bug"], limit: 10 })
+sia_search({ query: "verification requirements <area>", node_types: ["Convention"], limit: 5 })
+```
+
+Any `Bug` entity surfaced becomes an explicit verification target — the
+regression it describes MUST be covered by the run you are about to do.
+
+### Step 1 — Run the verification commands
+
+At minimum: `sia-verify` + `sia-test` against the current area. Add any
+area-specific gate surfaced in Step 0 (integration tests, typecheck,
+lint, schema-diff, etc.).
+
+### Step 2 — Read the output
+
+Read the full output, not just the last line. Check exit codes. If a
+test was skipped, ask why. If a suite short-circuited, ask why.
+
+### Step 3 — Check Concerns
+
+```
+nous_concern()
+```
+
+If an open Concern names the area you are claiming complete, do NOT
+claim completion. Surface the Concern and resolve or defer it
+explicitly.
+
+### Step 4 — Make the claim with evidence
+
+Pair every completion claim with the command output that supports it.
+"Tests pass" alone is not evidence — the command line and the summary
+line are.
+
+## Never claim done without
+
+- **Passing tests that weren't actually run.** Re-running is cheap.
+  Mental testing misses ~70% of regressions.
+- **Assumptions instead of observations.** "It should work" is not
+  evidence. The verification command output is.
+- **Silent fallbacks.** A skipped suite, a pre-existing failure
+  ignored, a warning downgraded to "known" — each one voids the
+  completion claim until investigated.
+
+## Relationship to other skills
+
+- `/sia-verify` — the area-aware verification gate. This skill invokes it.
+- `/sia-test` — the test-runner gate. This skill invokes it.
+- `/sia-finish` — finalises a branch. Always invoke this skill **before**
+  `/sia-finish`; a finish without prior verification is incomplete.
+
+## Key principle
+
+Evidence before assertions, always. If you cannot cite the command
+output that proves the claim, the claim is not verified yet.


### PR DESCRIPTION
## Summary

- New skill **`sia-verify-before-completion`** (48th skill) ports the superpowers `verification-before-completion` discipline with Sia's graph-powered past-failure lookup. Activates on pre-commit / pre-PR / pre-deploy.
- **`sia-brainstorm`** frontmatter rewritten to the superpowers mandate pattern ("You MUST use this before any creative work…"). Body unchanged (already tier-3).
- **`sia-finish`** gains one-line reference to the new verify skill.
- Count sync: `PLUGIN_USAGE.md` + `PLUGIN_README.md` Skills heading (47 → 48) + matching anchor update.

Closes roadmap entries #3 and #7. No version bump — user bumps on publish.

## Test plan

- [x] `bash scripts/count-plugin-components.sh` — skills 48 (was 47)
- [x] `bash scripts/validate-plugin.sh` — 9/9 OK
- [x] New skill body ≤ 150 lines (112 lines)