### PR TITLE
Phase A2: add next_steps hint helper across 18 MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ All notable changes to Sia are documented here. This project adheres to
   (leading `#` stripped, triple-backticks downgraded to single) so the
   downstream compactor sees well-formed markdown. Closes Phase 4
   §UserPromptSubmit gap; pushes concern surfacing from pull to push.
+- Shared `next_steps` hint helper at `src/mcp/next-steps.ts`; applied to 18 MCP tools (16 weak-trigger + 3 snapshot). Every response now chains to the next natural tool call. Closes Phase 5 §5.7 trigger-weakness gap.
+- New skill `sia-verify-before-completion` ports the superpowers
+  `verification-before-completion` discipline with Sia's graph-powered
+  past-failure lookup.
+
+### Changed
+
+- `sia-brainstorm` frontmatter rewritten to superpowers-style mandate:
+  "You MUST use this before any creative work…". Body unchanged.
 
 ## [1.3.3] — 2026-04-22
 

--- a/src/mcp/next-steps.ts
+++ b/src/mcp/next-steps.ts
@@ -1,0 +1,391 @@
+// Module: next-steps — Shared helper that builds structured "what to call next"
+// hints for MCP tool responses.
+//
+// Each MCP tool's handler returns a response object that MAY include an
+// optional `next_steps` array. The array chains the current tool to the next
+// natural tool call the agent should consider, closing the Phase 5 §5.7
+// "trigger weakness" gap where stand-alone tools feel like dead ends.
+//
+// Hints are intentionally terse — a `tool` name, a one-sentence `why`, and
+// (optionally) `args` the caller can spread straight into the next call.
+// Consumers are free to ignore them: `next_steps` is additive and optional
+// everywhere it appears.
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single structured suggestion for the next MCP tool call.
+ *
+ * Intentionally small — just the name of the tool, a one-line rationale,
+ * and optional argument hints the agent can forward.
+ */
+export interface NextStep {
+	/** The fully-qualified MCP tool name, e.g. `sia_search` or `sia_backlinks`. */
+	tool: string;
+	/** One-line reason. Agent-facing; keep under ~80 chars. */
+	why: string;
+	/** Optional args payload; may be spread directly into the suggested call. */
+	args?: Record<string, unknown>;
+}
+
+/**
+ * Loose context the helper uses to decide which hints apply.
+ *
+ * All fields optional — different tools populate different subsets.
+ * Only the fields the helper references are listed; everything else is
+ * forwarded opaquely so call sites can pass extra telemetry without
+ * tripping the type-checker.
+ */
+export interface NextStepsContext {
+	/** Result count (entities, communities, checks, etc.). */
+	resultCount?: number;
+	/** ID of the top / primary entity returned, when applicable. */
+	topEntityId?: string;
+	/** File path associated with the top result, when applicable. */
+	topFilePath?: string;
+	/** Kind of entity created / considered (`sia_note`). */
+	kind?: string;
+	/** Whether the response reports a failure (`sia_doctor`, `sia_upgrade`). */
+	hasFailure?: boolean;
+	/** Depth explored (used by `sia_expand` to suggest impact analysis). */
+	depthExplored?: number;
+	/** Tier 3 (LLM-inferred) count on the graph — used by `sia_stats`. */
+	tier3Count?: number;
+	/** Whether the graph is empty — used by `sia_stats`. */
+	emptyGraph?: boolean;
+	/** Branch name of the newest snapshot (`sia_snapshot_list`). */
+	newestBranchName?: string;
+	/** Files changed (`sia_detect_changes`) — used to propose impact calls. */
+	changedFiles?: string[];
+	/** Conflict flag — used by `sia_note` Decision flow. */
+	[extra: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// buildNextSteps
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `next_steps` array for the given tool + context.
+ *
+ * Returns `[]` when there is no natural chain to suggest (callers may then
+ * omit the `next_steps` field entirely). Always returns a fresh array — safe
+ * to mutate.
+ */
+export function buildNextSteps(toolName: string, context: NextStepsContext = {}): NextStep[] {
+	switch (toolName) {
+		case "sia_by_file":
+			return siaByFileHints(context);
+		case "sia_expand":
+			return siaExpandHints(context);
+		case "sia_community":
+			return siaCommunityHints(context);
+		case "sia_backlinks":
+			return siaBacklinksHints(context);
+		case "sia_note":
+			return siaNoteHints(context);
+		case "sia_stats":
+			return siaStatsHints(context);
+		case "sia_doctor":
+			return siaDoctorHints(context);
+		case "sia_upgrade":
+			return siaUpgradeHints(context);
+		case "sia_sync_status":
+			return siaSyncStatusHints(context);
+		case "sia_detect_changes":
+			return siaDetectChangesHints(context);
+		case "sia_index":
+			return siaIndexHints(context);
+		case "sia_batch_execute":
+			return siaBatchExecuteHints(context);
+		case "sia_fetch_and_index":
+			return siaFetchAndIndexHints(context);
+		case "sia_flag":
+			return siaFlagHints(context);
+		case "sia_models":
+			return siaModelsHints(context);
+		case "sia_snapshot_list":
+			return siaSnapshotListHints(context);
+		case "sia_snapshot_restore":
+			return siaSnapshotRestoreHints(context);
+		case "sia_snapshot_prune":
+			return siaSnapshotPruneHints(context);
+		default:
+			return [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-tool hint builders
+// ---------------------------------------------------------------------------
+
+function siaByFileHints(ctx: NextStepsContext): NextStep[] {
+	const hints: NextStep[] = [];
+	if ((ctx.resultCount ?? 0) > 0) {
+		hints.push({
+			tool: "sia_search",
+			why: "Find related decisions, conventions, or bugs tied to this file",
+		});
+		if (ctx.topEntityId) {
+			hints.push({
+				tool: "sia_backlinks",
+				why: "See which entities depend on the top hit",
+				args: { entity_id: ctx.topEntityId },
+			});
+		}
+	} else {
+		hints.push({
+			tool: "sia_search",
+			why: "No file hits — broaden via semantic search on the topic",
+		});
+	}
+	return hints;
+}
+
+function siaExpandHints(ctx: NextStepsContext): NextStep[] {
+	const hints: NextStep[] = [];
+	if (ctx.topFilePath) {
+		hints.push({
+			tool: "sia_by_file",
+			why: "Inspect all entities in the top neighbour's file",
+			args: { file_path: ctx.topFilePath },
+		});
+	}
+	if ((ctx.depthExplored ?? 0) >= 3 && ctx.topEntityId) {
+		hints.push({
+			tool: "sia_impact",
+			why: "Three+ layers reached — run blast-radius analysis",
+			args: { entity_id: ctx.topEntityId },
+		});
+	}
+	if (hints.length === 0) {
+		hints.push({
+			tool: "sia_impact",
+			why: "Assess blast radius of the expanded entity",
+			...(ctx.topEntityId ? { args: { entity_id: ctx.topEntityId } } : {}),
+		});
+	}
+	return hints;
+}
+
+function siaCommunityHints(ctx: NextStepsContext): NextStep[] {
+	const hints: NextStep[] = [];
+	if ((ctx.resultCount ?? 0) > 0 && ctx.topEntityId) {
+		hints.push({
+			tool: "sia_backlinks",
+			why: "Find dependents of the community-root entity",
+			args: { node_id: ctx.topEntityId },
+		});
+	}
+	hints.push({
+		tool: "sia_search",
+		why: "Drill into specific entities inside this community",
+	});
+	return hints;
+}
+
+function siaBacklinksHints(ctx: NextStepsContext): NextStep[] {
+	const hints: NextStep[] = [];
+	if ((ctx.resultCount ?? 0) > 0 && ctx.topEntityId) {
+		hints.push({
+			tool: "sia_expand",
+			why: "Walk one hop out from a prominent caller",
+			args: { entity_id: ctx.topEntityId },
+		});
+	}
+	hints.push({
+		tool: "sia_impact",
+		why: "Quantify blast radius if this node were changed",
+	});
+	return hints;
+}
+
+function siaNoteHints(ctx: NextStepsContext): NextStep[] {
+	const hints: NextStep[] = [
+		{
+			tool: "sia_search",
+			why: "Confirm no near-duplicate note already captured this",
+		},
+	];
+	if (ctx.kind === "Decision") {
+		hints.push({
+			tool: "sia_flag",
+			why: "Flag for conflict review if this decision supersedes prior context",
+		});
+	}
+	return hints;
+}
+
+function siaStatsHints(ctx: NextStepsContext): NextStep[] {
+	const hints: NextStep[] = [];
+	if (ctx.emptyGraph) {
+		hints.push({
+			tool: "/sia-learn",
+			why: "Graph is empty — bootstrap it from the current repo",
+		});
+		return hints;
+	}
+	if ((ctx.tier3Count ?? 0) > 5) {
+		hints.push({
+			tool: "/sia-capture",
+			why: "Many low-trust (Tier 3) entries — promote the worthwhile ones",
+		});
+	}
+	hints.push({
+		tool: "sia_doctor",
+		why: "Verify graph integrity now that you've seen the counts",
+	});
+	return hints;
+}
+
+function siaDoctorHints(ctx: NextStepsContext): NextStep[] {
+	if (ctx.hasFailure) {
+		return [
+			{
+				tool: "sia_upgrade",
+				why: "One or more checks failed — try upgrading first",
+				args: { dry_run: true },
+			},
+			{
+				tool: "/sia-setup",
+				why: "Alternative: re-run setup to repair runtimes/hooks/models",
+			},
+		];
+	}
+	return [
+		{
+			tool: "sia_stats",
+			why: "Healthy — inspect graph counts as a sanity check",
+		},
+	];
+}
+
+function siaUpgradeHints(ctx: NextStepsContext): NextStep[] {
+	if (ctx.hasFailure) {
+		return [
+			{
+				tool: "sia_doctor",
+				why: "Upgrade failed — run diagnostics to pinpoint the issue",
+			},
+		];
+	}
+	return [
+		{
+			tool: "sia_doctor",
+			why: "Post-upgrade: verify runtimes/FTS/graph are healthy",
+		},
+	];
+}
+
+function siaSyncStatusHints(ctx: NextStepsContext): NextStep[] {
+	if (ctx.hasFailure) {
+		return [
+			{
+				tool: "sia_doctor",
+				why: "Sync errored — run diagnostics to narrow the cause",
+			},
+		];
+	}
+	return [];
+}
+
+function siaDetectChangesHints(ctx: NextStepsContext): NextStep[] {
+	const files = ctx.changedFiles ?? [];
+	if (files.length === 0) return [];
+	return [
+		{
+			tool: "sia_impact",
+			why: "Assess blast radius over the changed files",
+		},
+		{
+			tool: "sia_by_file",
+			why: "Inspect entities tied to the first changed file",
+			args: { file_path: files[0] },
+		},
+	];
+}
+
+function siaIndexHints(ctx: NextStepsContext): NextStep[] {
+	if ((ctx.resultCount ?? 0) === 0) return [];
+	return [
+		{
+			tool: "sia_search",
+			why: "Confirm the newly indexed chunks are retrievable",
+		},
+	];
+}
+
+function siaBatchExecuteHints(ctx: NextStepsContext): NextStep[] {
+	if (ctx.hasFailure) {
+		return [
+			{
+				tool: "sia_doctor",
+				why: "One or more operations errored — run diagnostics",
+			},
+		];
+	}
+	return [];
+}
+
+function siaFetchAndIndexHints(ctx: NextStepsContext): NextStep[] {
+	if (ctx.hasFailure) return [];
+	return [
+		{
+			tool: "sia_search",
+			why: "Verify the fetched content is now searchable",
+		},
+	];
+}
+
+function siaFlagHints(ctx: NextStepsContext): NextStep[] {
+	if (ctx.hasFailure) return [];
+	return [
+		{
+			tool: "sia_search",
+			why: "Re-run the query that triggered the flag with fresh context",
+		},
+	];
+}
+
+function siaModelsHints(_ctx: NextStepsContext): NextStep[] {
+	return [
+		{
+			tool: "sia_doctor",
+			why: "Cross-check runtimes and ONNX model health",
+		},
+	];
+}
+
+function siaSnapshotListHints(ctx: NextStepsContext): NextStep[] {
+	if ((ctx.resultCount ?? 0) === 0) return [];
+	if (ctx.newestBranchName) {
+		return [
+			{
+				tool: "sia_snapshot_restore",
+				why: "Restore the newest snapshot",
+				args: { branch_name: ctx.newestBranchName },
+			},
+		];
+	}
+	return [];
+}
+
+function siaSnapshotRestoreHints(_ctx: NextStepsContext): NextStep[] {
+	return [
+		{
+			tool: "sia_doctor",
+			why: "Verify graph integrity after restore",
+		},
+	];
+}
+
+function siaSnapshotPruneHints(_ctx: NextStepsContext): NextStep[] {
+	return [
+		{
+			tool: "sia_snapshot_list",
+			why: "Confirm the remaining snapshots post-prune",
+		},
+	];
+}

--- a/src/mcp/tools/sia-backlinks.ts
+++ b/src/mcp/tools/sia-backlinks.ts
@@ -1,6 +1,7 @@
 // Module: sia-backlinks — Backlink traversal for knowledge graph nodes
 
 import type { SiaDb } from "@/graph/db-interface";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 
 export interface SiaBacklinksInput {
 	node_id: string;
@@ -20,6 +21,7 @@ export interface SiaBacklinksResult {
 	target_id: string;
 	backlinks: Record<string, BacklinkEntry[]>; // grouped by edge_type
 	total_count: number;
+	next_steps?: NextStep[];
 }
 
 /**
@@ -79,9 +81,26 @@ export async function handleSiaBacklinks(
 		totalCount++;
 	}
 
-	return {
+	// Grab the most-important caller (first entry across all groups) for
+	// the hint's `entity_id` arg, if one exists.
+	let topCallerId: string | undefined;
+	for (const group of Object.values(backlinks)) {
+		if (group.length > 0) {
+			topCallerId = group[0].id;
+			break;
+		}
+	}
+
+	const nextSteps = buildNextSteps("sia_backlinks", {
+		resultCount: totalCount,
+		topEntityId: topCallerId,
+	});
+
+	const response: SiaBacklinksResult = {
 		target_id: input.node_id,
 		backlinks,
 		total_count: totalCount,
 	};
+	if (nextSteps.length > 0) response.next_steps = nextSteps;
+	return response;
 }

--- a/src/mcp/tools/sia-batch-execute.ts
+++ b/src/mcp/tools/sia-batch-execute.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { Embedder } from "@/capture/embedder";
 import type { SiaDb } from "@/graph/db-interface";
 import { insertEdge } from "@/graph/edges";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { ProgressiveThrottle } from "@/retrieval/throttle";
 import { buildSandboxEnv } from "@/sandbox/credential-pass";
 import { executeSubprocess } from "@/sandbox/executor";
@@ -45,6 +46,7 @@ export interface SiaBatchExecuteResult {
 	eventNodeIds: string[];
 	contextSavings: number;
 	error?: string;
+	next_steps?: NextStep[];
 }
 
 const BATCH_MAX = 20;
@@ -161,9 +163,13 @@ export async function handleSiaBatchExecute(
 		}
 	}
 
-	return {
+	const hasFailure = results.some((r) => r.error !== undefined);
+	const nextSteps = buildNextSteps("sia_batch_execute", { hasFailure });
+	const response: SiaBatchExecuteResult = {
 		results,
 		eventNodeIds,
 		contextSavings: 0,
 	};
+	if (nextSteps.length > 0) response.next_steps = nextSteps;
+	return response;
 }

--- a/src/mcp/tools/sia-by-file.ts
+++ b/src/mcp/tools/sia-by-file.ts
@@ -5,6 +5,7 @@ import type { FeedbackCollector } from "@/feedback/collector";
 import type { SiaDb } from "@/graph/db-interface";
 import type { Entity } from "@/graph/entities";
 import { annotateFreshness } from "@/mcp/freshness-annotator";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaByFileInput } from "@/mcp/server";
 import type { WorkspaceDeps } from "@/mcp/tools/sia-search";
 import { workspaceSearch } from "@/retrieval/workspace-search";
@@ -18,6 +19,7 @@ export interface FeedbackDeps {
 /** Result shape — same as SiaSearchResult (array of entities). */
 export interface SiaByFileResult {
 	entities: Entity[];
+	next_steps?: NextStep[];
 }
 
 /**
@@ -54,7 +56,7 @@ export async function handleSiaByFile(
 		);
 		const entities = annotated as unknown as Entity[];
 		await recordByFileFeedback(feedbackDeps, filePath, entities);
-		return { entities };
+		return withNextSteps(entities);
 	}
 
 	// --- Exact match ---
@@ -75,7 +77,7 @@ export async function handleSiaByFile(
 		);
 		const entities = annotated as unknown as Entity[];
 		await recordByFileFeedback(feedbackDeps, filePath, entities);
-		return { entities };
+		return withNextSteps(entities);
 	}
 
 	// --- Filename stem fallback ---
@@ -99,7 +101,16 @@ export async function handleSiaByFile(
 	);
 	const entities = annotated as unknown as Entity[];
 	await recordByFileFeedback(feedbackDeps, filePath, entities);
-	return { entities };
+	return withNextSteps(entities);
+}
+
+/** Build a {@link SiaByFileResult} with `next_steps` populated. */
+function withNextSteps(entities: Entity[]): SiaByFileResult {
+	const nextSteps = buildNextSteps("sia_by_file", {
+		resultCount: entities.length,
+		topEntityId: entities[0]?.id,
+	});
+	return nextSteps.length > 0 ? { entities, next_steps: nextSteps } : { entities };
 }
 
 /**

--- a/src/mcp/tools/sia-community.ts
+++ b/src/mcp/tools/sia-community.ts
@@ -6,6 +6,7 @@
 
 import type { z } from "zod";
 import type { SiaDb } from "@/graph/db-interface";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaCommunityInput } from "@/mcp/server";
 
 /** Shape returned for each community in sia_community results. */
@@ -22,6 +23,7 @@ export interface CommunitySummary {
 export interface SiaCommunityResult {
 	communities: CommunitySummary[];
 	global_unavailable?: boolean;
+	next_steps?: NextStep[];
 }
 
 /** Maximum number of community results returned. */
@@ -109,5 +111,9 @@ export async function handleSiaCommunity(
 		}
 	}
 
-	return { communities };
+	const nextSteps = buildNextSteps("sia_community", {
+		resultCount: communities.length,
+		topEntityId: communities[0]?.id,
+	});
+	return nextSteps.length > 0 ? { communities, next_steps: nextSteps } : { communities };
 }

--- a/src/mcp/tools/sia-detect-changes.ts
+++ b/src/mcp/tools/sia-detect-changes.ts
@@ -3,6 +3,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { SiaDb } from "@/graph/db-interface";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 
 const execFileAsync = promisify(execFile);
 
@@ -26,6 +27,7 @@ export interface ChangedFile {
 export interface DetectChangesResult {
 	files_changed: ChangedFile[];
 	total_entities_affected: number;
+	next_steps?: NextStep[];
 }
 
 /** Type alias for the git diff runner; injectable for testing. */
@@ -143,8 +145,13 @@ export async function handleSiaDetectChanges(
 		});
 	}
 
-	return {
+	const nextSteps = buildNextSteps("sia_detect_changes", {
+		changedFiles: filesChanged.map((f) => f.path),
+	});
+	const response: DetectChangesResult = {
 		files_changed: filesChanged,
 		total_entities_affected: totalEntities,
 	};
+	if (nextSteps.length > 0) response.next_steps = nextSteps;
+	return response;
 }

--- a/src/mcp/tools/sia-doctor.ts
+++ b/src/mcp/tools/sia-doctor.ts
@@ -2,6 +2,7 @@
 
 import type { z } from "zod";
 import type { SiaDb } from "@/graph/db-interface";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaDoctorInput } from "@/mcp/server";
 import { RUNTIME_MAP } from "@/sandbox/executor";
 import {
@@ -20,6 +21,7 @@ export interface SiaDoctorResult {
 	checks: DiagnosticCheck[];
 	healthy: boolean;
 	warnings: string[];
+	next_steps?: NextStep[];
 }
 
 // ---------------------------------------------------------------------------
@@ -69,5 +71,8 @@ export async function handleSiaDoctor(
 	const healthy = checks.every((c) => c.status === "ok");
 	const warnings = checks.filter((c) => c.status !== "ok").map((c) => c.message);
 
-	return { checks, healthy, warnings };
+	const nextSteps = buildNextSteps("sia_doctor", { hasFailure: !healthy });
+	const response: SiaDoctorResult = { checks, healthy, warnings };
+	if (nextSteps.length > 0) response.next_steps = nextSteps;
+	return response;
 }

--- a/src/mcp/tools/sia-expand.ts
+++ b/src/mcp/tools/sia-expand.ts
@@ -7,6 +7,7 @@ import type { SiaDb } from "@/graph/db-interface";
 import type { EdgeRow } from "@/graph/edges";
 import type { Entity } from "@/graph/entities";
 import { annotateFreshness } from "@/mcp/freshness-annotator";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaExpandInput } from "@/mcp/server";
 
 /** Optional dependencies for recording agent feedback signals. */
@@ -21,6 +22,7 @@ export interface SiaExpandResult {
 	neighbors: Entity[];
 	edges: EdgeRow[];
 	edge_count: number;
+	next_steps?: NextStep[];
 }
 
 /** Error result when root entity is not found. */
@@ -174,10 +176,35 @@ export async function handleSiaExpand(
 		}
 	}
 
-	return {
+	const neighborEntities = annotatedNeighbors as unknown as Entity[];
+	// `file_paths` is a JSON-encoded string array on each row. Parse the first
+	// entry defensively so a malformed value simply yields no hint.
+	let topFilePath: string | undefined;
+	const rawFilePaths = neighborEntities[0]?.file_paths;
+	if (typeof rawFilePaths === "string" && rawFilePaths.length > 0) {
+		try {
+			const parsed = JSON.parse(rawFilePaths) as unknown;
+			if (Array.isArray(parsed) && typeof parsed[0] === "string") {
+				topFilePath = parsed[0];
+			}
+		} catch {
+			// ignore malformed file_paths for hint purposes
+		}
+	}
+
+	const nextSteps = buildNextSteps("sia_expand", {
+		resultCount: neighborEntities.length,
+		topEntityId: input.entity_id,
+		topFilePath,
+		depthExplored: depth,
+	});
+
+	const result: SiaExpandResult = {
 		entity: annotatedRoot as unknown as Entity,
-		neighbors: annotatedNeighbors as unknown as Entity[],
+		neighbors: neighborEntities,
 		edges: dedupedEdges.slice(0, MAX_EDGES),
 		edge_count: totalEdgeCount,
 	};
+	if (nextSteps.length > 0) result.next_steps = nextSteps;
+	return result;
 }

--- a/src/mcp/tools/sia-fetch-and-index.ts
+++ b/src/mcp/tools/sia-fetch-and-index.ts
@@ -6,6 +6,7 @@ import TurndownService from "turndown";
 import { z } from "zod";
 import type { Embedder } from "@/capture/embedder";
 import type { SiaDb } from "@/graph/db-interface";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import { contentTypeChunker } from "@/sandbox/context-mode";
 
 // ---------------------------------------------------------------------------
@@ -24,6 +25,7 @@ export interface SiaFetchAndIndexResult {
 	sourceUrl?: string;
 	externalRefId?: string;
 	error?: string;
+	next_steps?: NextStep[];
 }
 
 // ---------------------------------------------------------------------------
@@ -232,10 +234,13 @@ export async function handleSiaFetchAndIndex(
 	);
 
 	// 9. Return result
-	return {
+	const nextSteps = buildNextSteps("sia_fetch_and_index", { hasFailure: false });
+	const result: SiaFetchAndIndexResult = {
 		indexed: chunkIds.length,
 		contentType,
 		sourceUrl: url,
 		externalRefId,
 	};
+	if (nextSteps.length > 0) result.next_steps = nextSteps;
+	return result;
 }

--- a/src/mcp/tools/sia-flag.ts
+++ b/src/mcp/tools/sia-flag.ts
@@ -7,6 +7,7 @@ import { v4 as uuid } from "uuid";
 import type { z } from "zod";
 import type { Embedder } from "@/capture/embedder";
 import type { SiaDb } from "@/graph/db-interface";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaFlagInput as SiaFlagInputSchema } from "@/mcp/server";
 
 export type SiaFlagInput = z.infer<typeof SiaFlagInputSchema>;
@@ -20,6 +21,7 @@ export interface SiaFlagResult {
 	flagged?: boolean;
 	id?: string;
 	error?: string;
+	next_steps?: NextStep[];
 }
 
 /**
@@ -139,5 +141,8 @@ export async function handleSiaFlag(
 		}
 	}
 
-	return { flagged: true, id };
+	const nextSteps = buildNextSteps("sia_flag", { hasFailure: false });
+	return nextSteps.length > 0
+		? { flagged: true, id, next_steps: nextSteps }
+		: { flagged: true, id };
 }

--- a/src/mcp/tools/sia-index.ts
+++ b/src/mcp/tools/sia-index.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { Embedder } from "@/capture/embedder";
 import type { SiaDb } from "@/graph/db-interface";
 import { insertEdge } from "@/graph/edges";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import { headingChunker } from "@/sandbox/context-mode";
 
 // ---------------------------------------------------------------------------
@@ -21,6 +22,7 @@ export interface SiaIndexResult {
 	indexed: number;
 	references: number;
 	chunkIds: string[];
+	next_steps?: NextStep[];
 }
 
 // ---------------------------------------------------------------------------
@@ -103,9 +105,12 @@ export async function handleSiaIndex(
 		}
 	}
 
-	return {
+	const nextSteps = buildNextSteps("sia_index", { resultCount: chunkIds.length });
+	const response: SiaIndexResult = {
 		indexed: chunkIds.length,
 		references: referenceCount,
 		chunkIds,
 	};
+	if (nextSteps.length > 0) response.next_steps = nextSteps;
+	return response;
 }

--- a/src/mcp/tools/sia-models.ts
+++ b/src/mcp/tools/sia-models.ts
@@ -1,6 +1,7 @@
 // Module: sia-models — MCP tool for model tier status inspection
 
 import { z } from "zod";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { ModelManager } from "@/models/manager";
 
 export const SiaModelsInput = z.object({
@@ -10,19 +11,34 @@ export const SiaModelsInput = z.object({
 export type SiaModelsInputType = z.infer<typeof SiaModelsInput>;
 
 /**
+ * Structured response for `sia_models`.
+ *
+ * Historically the handler returned a bare string. With Phase A2 we return
+ * a small envelope so the MCP response can carry both the formatted text
+ * and a `next_steps` array. Existing behaviour is preserved via the `text`
+ * field — consumers that previously read the string should read `text`.
+ */
+export interface SiaModelsResult {
+	text: string;
+	next_steps?: NextStep[];
+}
+
+/**
  * Handle the sia_models MCP tool.
  *
  * Returns a human-readable summary of the installed model tier, individual
- * model entries, attention head training phase, and total disk usage.
+ * model entries, attention head training phase, and total disk usage, plus
+ * a `next_steps` hint array.
  */
 export function handleSiaModels(
 	input: SiaModelsInputType,
 	modelManager: ModelManager | null,
-): string {
+): SiaModelsResult {
 	if (!modelManager) {
-		return "Model manager not available. Run `sia setup` to initialize.";
+		return { text: "Model manager not available. Run `sia setup` to initialize." };
 	}
 
+	let text: string;
 	if (input.action === "status") {
 		const manifest = modelManager.getManifest();
 
@@ -35,7 +51,7 @@ export function handleSiaModels(
 
 		const totalSize = Object.values(manifest.models).reduce((sum, e) => sum + e.sizeBytes, 0);
 
-		return [
+		text = [
 			`Installed tier: ${manifest.installedTier}`,
 			`Models:`,
 			modelLines || "  (none installed)",
@@ -43,7 +59,10 @@ export function handleSiaModels(
 			`Attention head: ${manifest.attentionHead.trainingPhase} (${manifest.attentionHead.feedbackEvents} feedback events)`,
 			`Total disk usage: ${(totalSize / 1_048_576).toFixed(0)} MB`,
 		].join("\n");
+	} else {
+		text = `Unknown action: ${input.action}`;
 	}
 
-	return `Unknown action: ${input.action}`;
+	const nextSteps = buildNextSteps("sia_models", {});
+	return nextSteps.length > 0 ? { text, next_steps: nextSteps } : { text };
 }

--- a/src/mcp/tools/sia-note.ts
+++ b/src/mcp/tools/sia-note.ts
@@ -2,6 +2,7 @@
 
 import type { SiaDb } from "@/graph/db-interface";
 import type { Entity } from "@/graph/entities";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import { OntologyError } from "@/ontology/errors";
 import {
 	createBug,
@@ -24,6 +25,7 @@ export interface SiaNoteResult {
 	node_id: string;
 	kind: string;
 	edges_created: number;
+	next_steps?: NextStep[];
 }
 
 /**
@@ -133,11 +135,14 @@ export async function handleSiaNote(db: SiaDb, input: SiaNoteInput): Promise<Sia
 			}
 		}
 
-		return {
+		const nextSteps = buildNextSteps("sia_note", { kind: input.kind });
+		const response: SiaNoteResult = {
 			node_id: entity.id,
 			kind: input.kind,
 			edges_created: edgesCreated,
 		};
+		if (nextSteps.length > 0) response.next_steps = nextSteps;
+		return response;
 	} catch (err) {
 		if (err instanceof OntologyError) {
 			throw new Error(`sia_note failed: ${err.message}`);

--- a/src/mcp/tools/sia-snapshot-list.ts
+++ b/src/mcp/tools/sia-snapshot-list.ts
@@ -2,6 +2,7 @@
 
 import type { SiaDb } from "@/graph/db-interface";
 import { listBranchSnapshots } from "@/graph/snapshots";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 
 // ---------------------------------------------------------------------------
 // SiaSnapshotListRow — one row per branch snapshot
@@ -22,6 +23,7 @@ export interface SiaSnapshotListRow {
 export interface SiaSnapshotListResult {
 	snapshots: SiaSnapshotListRow[];
 	error?: string;
+	next_steps?: NextStep[];
 }
 
 // ---------------------------------------------------------------------------
@@ -40,15 +42,21 @@ export interface SiaSnapshotListResult {
 export async function handleSiaSnapshotList(db: SiaDb): Promise<SiaSnapshotListResult> {
 	try {
 		const snapshots = await listBranchSnapshots(db);
-		return {
-			snapshots: snapshots.map((s) => ({
-				branch_name: s.branch_name,
-				commit_hash: s.commit_hash,
-				node_count: s.node_count,
-				edge_count: s.edge_count,
-				updated_at: s.updated_at,
-			})),
-		};
+		const rows = snapshots.map((s) => ({
+			branch_name: s.branch_name,
+			commit_hash: s.commit_hash,
+			node_count: s.node_count,
+			edge_count: s.edge_count,
+			updated_at: s.updated_at,
+		}));
+		// `listBranchSnapshots` returns newest-first, so the first row is the newest.
+		const nextSteps = buildNextSteps("sia_snapshot_list", {
+			resultCount: rows.length,
+			newestBranchName: rows[0]?.branch_name,
+		});
+		const response: SiaSnapshotListResult = { snapshots: rows };
+		if (nextSteps.length > 0) response.next_steps = nextSteps;
+		return response;
 	} catch (err) {
 		return {
 			snapshots: [],

--- a/src/mcp/tools/sia-snapshot-prune.ts
+++ b/src/mcp/tools/sia-snapshot-prune.ts
@@ -3,6 +3,7 @@
 import type { z } from "zod";
 import type { SiaDb } from "@/graph/db-interface";
 import { pruneBranchSnapshots } from "@/graph/snapshots";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaSnapshotPruneInput } from "@/mcp/server";
 import { validateBranchNames } from "@/mcp/tools/sia-snapshot-shared";
 
@@ -13,6 +14,7 @@ import { validateBranchNames } from "@/mcp/tools/sia-snapshot-shared";
 export interface SiaSnapshotPruneResult {
 	pruned: number;
 	branch_names: string[];
+	next_steps?: NextStep[];
 }
 
 // ---------------------------------------------------------------------------
@@ -33,5 +35,8 @@ export async function handleSiaSnapshotPrune(
 ): Promise<SiaSnapshotPruneResult> {
 	const branchNames = validateBranchNames(input.branch_names);
 	const pruned = await pruneBranchSnapshots(db, branchNames);
-	return { pruned, branch_names: branchNames };
+	const nextSteps = buildNextSteps("sia_snapshot_prune", {});
+	const response: SiaSnapshotPruneResult = { pruned, branch_names: branchNames };
+	if (nextSteps.length > 0) response.next_steps = nextSteps;
+	return response;
 }

--- a/src/mcp/tools/sia-snapshot-restore.ts
+++ b/src/mcp/tools/sia-snapshot-restore.ts
@@ -3,6 +3,7 @@
 import type { z } from "zod";
 import type { SiaDb } from "@/graph/db-interface";
 import { restoreBranchSnapshot } from "@/graph/snapshots";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaSnapshotRestoreInput } from "@/mcp/server";
 import { validateBranchName } from "@/mcp/tools/sia-snapshot-shared";
 
@@ -13,6 +14,7 @@ import { validateBranchName } from "@/mcp/tools/sia-snapshot-shared";
 export interface SiaSnapshotRestoreResult {
 	restored: boolean;
 	branch_name: string;
+	next_steps?: NextStep[];
 }
 
 // ---------------------------------------------------------------------------
@@ -33,5 +35,8 @@ export async function handleSiaSnapshotRestore(
 ): Promise<SiaSnapshotRestoreResult> {
 	const branchName = validateBranchName(input.branch_name);
 	const restored = await restoreBranchSnapshot(db, branchName);
-	return { restored, branch_name: branchName };
+	const nextSteps = buildNextSteps("sia_snapshot_restore", {});
+	const response: SiaSnapshotRestoreResult = { restored, branch_name: branchName };
+	if (nextSteps.length > 0) response.next_steps = nextSteps;
+	return response;
 }

--- a/src/mcp/tools/sia-stats.ts
+++ b/src/mcp/tools/sia-stats.ts
@@ -2,6 +2,7 @@
 
 import type { z } from "zod";
 import type { SiaDb } from "@/graph/db-interface";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaStatsInput } from "@/mcp/server";
 
 export interface SiaStatsResult {
@@ -9,6 +10,7 @@ export interface SiaStatsResult {
 	edges: Record<string, number>;
 	session?: { callCounts: Record<string, number> };
 	error?: string;
+	next_steps?: NextStep[];
 }
 
 /**
@@ -41,6 +43,22 @@ export async function handleSiaStats(
 			edges[row.type as string] = row.count as number;
 		}
 
+		// Derive hint-relevant counts: total active entities + tier-3 subset.
+		const totalEntities = Object.values(nodes).reduce((sum, n) => sum + n, 0);
+		let tier3Count = 0;
+		try {
+			const { rows: tier3Rows } = await db.execute(
+				"SELECT COUNT(*) AS cnt FROM graph_nodes WHERE trust_tier = 3 AND t_expired IS NULL",
+			);
+			tier3Count = (tier3Rows[0]?.cnt as number) ?? 0;
+		} catch {
+			// Non-fatal: if trust_tier column is absent for any reason, skip the hint.
+		}
+		const nextSteps = buildNextSteps("sia_stats", {
+			emptyGraph: totalEntities === 0,
+			tier3Count,
+		});
+
 		// Optional session stats from search_throttle
 		if (input.include_session && sessionId) {
 			const { rows: throttleRows } = await db.execute(
@@ -53,10 +71,14 @@ export async function handleSiaStats(
 				callCounts[row.tool_name as string] = row.call_count as number;
 			}
 
-			return { nodes, edges, session: { callCounts } };
+			const sessionResponse: SiaStatsResult = { nodes, edges, session: { callCounts } };
+			if (nextSteps.length > 0) sessionResponse.next_steps = nextSteps;
+			return sessionResponse;
 		}
 
-		return { nodes, edges };
+		const response: SiaStatsResult = { nodes, edges };
+		if (nextSteps.length > 0) response.next_steps = nextSteps;
+		return response;
 	} catch (err) {
 		return { nodes: {}, edges: {}, error: `Stats query failed: ${(err as Error).message}` };
 	}

--- a/src/mcp/tools/sia-sync-status.ts
+++ b/src/mcp/tools/sia-sync-status.ts
@@ -3,6 +3,7 @@
 // Returns the current sync configuration and status.
 // Read-only — does not require a database connection.
 
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import { getConfig, resolveSiaHome } from "@/shared/config";
 
 export interface SiaSyncStatusResult {
@@ -12,6 +13,7 @@ export interface SiaSyncStatusResult {
 	developer_id?: string;
 	sync_interval_seconds?: number;
 	error?: string;
+	next_steps?: NextStep[];
 }
 
 /**
@@ -35,10 +37,13 @@ export async function handleSiaSyncStatus(): Promise<SiaSyncStatusResult> {
 		};
 	} catch (err) {
 		console.error("[sia] sia_sync_status error:", err);
-		return {
+		const nextSteps = buildNextSteps("sia_sync_status", { hasFailure: true });
+		const response: SiaSyncStatusResult = {
 			enabled: false,
 			status: "error",
 			error: err instanceof Error ? err.message : String(err),
 		};
+		if (nextSteps.length > 0) response.next_steps = nextSteps;
+		return response;
 	}
 }

--- a/src/mcp/tools/sia-upgrade.ts
+++ b/src/mcp/tools/sia-upgrade.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { z } from "zod";
 import type { SiaDb } from "@/graph/db-interface";
+import { buildNextSteps, type NextStep } from "@/mcp/next-steps";
 import type { SiaUpgradeInput } from "@/mcp/server";
 
 // ---------------------------------------------------------------------------
@@ -30,6 +31,7 @@ export interface SiaUpgradeResult {
 	vssRebuilt?: boolean;
 	dryRun?: boolean;
 	error?: string;
+	next_steps?: NextStep[];
 }
 
 // ---------------------------------------------------------------------------
@@ -202,16 +204,22 @@ export async function handleSiaUpgrade(
 
 	// 3. If dry_run → return early
 	if (dryRun) {
-		return { previousVersion, strategy: type, dryRun: true };
+		const dryNext = buildNextSteps("sia_upgrade", { hasFailure: false });
+		const dryResp: SiaUpgradeResult = { previousVersion, strategy: type, dryRun: true };
+		if (dryNext.length > 0) dryResp.next_steps = dryNext;
+		return dryResp;
 	}
 
 	// Guard: if version is unknown, rollback would be impossible
 	if (previousVersion === "unknown") {
-		return {
+		const unknownNext = buildNextSteps("sia_upgrade", { hasFailure: true });
+		const unknownResp: SiaUpgradeResult = {
 			previousVersion,
 			strategy: type,
 			error: "Cannot determine current version — rollback would be impossible. Aborting upgrade.",
 		};
+		if (unknownNext.length > 0) unknownResp.next_steps = unknownNext;
+		return unknownResp;
 	}
 
 	// 4. Try update → on failure, try rollback
@@ -227,16 +235,20 @@ export async function handleSiaUpgrade(
 			rollbackMsg = ` (rollback also failed: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)})`;
 		}
 
-		return {
+		const failNext = buildNextSteps("sia_upgrade", { hasFailure: true });
+		const failResp: SiaUpgradeResult = {
 			previousVersion,
 			strategy: type,
 			error: `${updateErr instanceof Error ? updateErr.message : String(updateErr)}${rollbackMsg}`,
 		};
+		if (failNext.length > 0) failResp.next_steps = failNext;
+		return failResp;
 	}
 
 	// 5. Return success result
 	const newVersion = strategy.currentVersion();
-	return {
+	const nextSteps = buildNextSteps("sia_upgrade", { hasFailure: false });
+	const response: SiaUpgradeResult = {
 		previousVersion,
 		newVersion,
 		strategy: type,
@@ -244,4 +256,6 @@ export async function handleSiaUpgrade(
 		hooksReconfigured: false,
 		vssRebuilt: false,
 	};
+	if (nextSteps.length > 0) response.next_steps = nextSteps;
+	return response;
 }

--- a/tests/unit/mcp/next-steps.test.ts
+++ b/tests/unit/mcp/next-steps.test.ts
@@ -1,0 +1,312 @@
+// Tests for the shared next-steps hint helper.
+
+import { describe, expect, it } from "vitest";
+import { buildNextSteps } from "@/mcp/next-steps";
+
+describe("buildNextSteps", () => {
+	it("returns [] for an unknown tool", () => {
+		expect(buildNextSteps("no_such_tool", {})).toEqual([]);
+	});
+
+	// ---------------------------------------------------------------
+	// sia_by_file branches
+	// ---------------------------------------------------------------
+
+	describe("sia_by_file", () => {
+		it("suggests sia_search and sia_backlinks on hits", () => {
+			const hints = buildNextSteps("sia_by_file", {
+				resultCount: 3,
+				topEntityId: "ent-1",
+			});
+			const tools = hints.map((h) => h.tool);
+			expect(tools).toContain("sia_search");
+			expect(tools).toContain("sia_backlinks");
+			const bl = hints.find((h) => h.tool === "sia_backlinks");
+			expect(bl?.args?.entity_id).toBe("ent-1");
+		});
+
+		it("suggests broader search on zero hits", () => {
+			const hints = buildNextSteps("sia_by_file", { resultCount: 0 });
+			expect(hints.length).toBeGreaterThan(0);
+			expect(hints[0].tool).toBe("sia_search");
+			expect(hints.map((h) => h.tool)).not.toContain("sia_backlinks");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_expand branches
+	// ---------------------------------------------------------------
+
+	describe("sia_expand", () => {
+		it("suggests sia_by_file with the top file path", () => {
+			const hints = buildNextSteps("sia_expand", {
+				resultCount: 5,
+				topEntityId: "ent-1",
+				topFilePath: "src/auth.ts",
+				depthExplored: 1,
+			});
+			const bf = hints.find((h) => h.tool === "sia_by_file");
+			expect(bf).toBeDefined();
+			expect(bf?.args?.file_path).toBe("src/auth.ts");
+		});
+
+		it("suggests sia_impact when ≥ 3 layers expanded", () => {
+			const hints = buildNextSteps("sia_expand", {
+				topEntityId: "ent-1",
+				topFilePath: "src/foo.ts",
+				depthExplored: 3,
+			});
+			expect(hints.map((h) => h.tool)).toContain("sia_impact");
+		});
+
+		it("falls back to sia_impact when no file path known", () => {
+			const hints = buildNextSteps("sia_expand", { topEntityId: "ent-1", depthExplored: 1 });
+			expect(hints.map((h) => h.tool)).toContain("sia_impact");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_community
+	// ---------------------------------------------------------------
+
+	describe("sia_community", () => {
+		it("suggests sia_backlinks on community root + sia_search", () => {
+			const hints = buildNextSteps("sia_community", { resultCount: 2, topEntityId: "c-1" });
+			const tools = hints.map((h) => h.tool);
+			expect(tools).toContain("sia_backlinks");
+			expect(tools).toContain("sia_search");
+			const bl = hints.find((h) => h.tool === "sia_backlinks");
+			expect(bl?.args?.node_id).toBe("c-1");
+		});
+
+		it("still suggests sia_search when no community found", () => {
+			const hints = buildNextSteps("sia_community", { resultCount: 0 });
+			expect(hints.map((h) => h.tool)).toContain("sia_search");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_backlinks
+	// ---------------------------------------------------------------
+
+	describe("sia_backlinks", () => {
+		it("suggests sia_expand on the top caller", () => {
+			const hints = buildNextSteps("sia_backlinks", { resultCount: 2, topEntityId: "caller-1" });
+			const exp = hints.find((h) => h.tool === "sia_expand");
+			expect(exp?.args?.entity_id).toBe("caller-1");
+		});
+
+		it("always suggests sia_impact", () => {
+			const hints = buildNextSteps("sia_backlinks", { resultCount: 0 });
+			expect(hints.map((h) => h.tool)).toContain("sia_impact");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_note
+	// ---------------------------------------------------------------
+
+	describe("sia_note", () => {
+		it("suggests sia_search for dedup verification", () => {
+			const hints = buildNextSteps("sia_note", { kind: "Convention" });
+			expect(hints.map((h) => h.tool)).toContain("sia_search");
+			expect(hints.map((h) => h.tool)).not.toContain("sia_flag");
+		});
+
+		it("suggests sia_flag when kind=Decision", () => {
+			const hints = buildNextSteps("sia_note", { kind: "Decision" });
+			expect(hints.map((h) => h.tool)).toContain("sia_flag");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_stats
+	// ---------------------------------------------------------------
+
+	describe("sia_stats", () => {
+		it("suggests /sia-learn on an empty graph", () => {
+			const hints = buildNextSteps("sia_stats", { emptyGraph: true });
+			expect(hints.map((h) => h.tool)).toContain("/sia-learn");
+		});
+
+		it("suggests /sia-capture when tier-3 count > 5", () => {
+			const hints = buildNextSteps("sia_stats", { tier3Count: 12 });
+			expect(hints.map((h) => h.tool)).toContain("/sia-capture");
+		});
+
+		it("suggests sia_doctor for normal graphs", () => {
+			const hints = buildNextSteps("sia_stats", { tier3Count: 0 });
+			expect(hints.map((h) => h.tool)).toContain("sia_doctor");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_doctor
+	// ---------------------------------------------------------------
+
+	describe("sia_doctor", () => {
+		it("suggests sia_upgrade and /sia-setup on failure", () => {
+			const hints = buildNextSteps("sia_doctor", { hasFailure: true });
+			const tools = hints.map((h) => h.tool);
+			expect(tools).toContain("sia_upgrade");
+			expect(tools).toContain("/sia-setup");
+		});
+
+		it("suggests sia_stats when healthy", () => {
+			const hints = buildNextSteps("sia_doctor", { hasFailure: false });
+			expect(hints.map((h) => h.tool)).toContain("sia_stats");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_upgrade
+	// ---------------------------------------------------------------
+
+	describe("sia_upgrade", () => {
+		it("suggests sia_doctor on success", () => {
+			const hints = buildNextSteps("sia_upgrade", { hasFailure: false });
+			expect(hints.map((h) => h.tool)).toContain("sia_doctor");
+		});
+
+		it("suggests sia_doctor on failure too", () => {
+			const hints = buildNextSteps("sia_upgrade", { hasFailure: true });
+			expect(hints.map((h) => h.tool)).toContain("sia_doctor");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_sync_status
+	// ---------------------------------------------------------------
+
+	describe("sia_sync_status", () => {
+		it("returns no hints on normal status", () => {
+			expect(buildNextSteps("sia_sync_status", { hasFailure: false })).toEqual([]);
+		});
+
+		it("suggests sia_doctor on errors", () => {
+			const hints = buildNextSteps("sia_sync_status", { hasFailure: true });
+			expect(hints.map((h) => h.tool)).toContain("sia_doctor");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_detect_changes
+	// ---------------------------------------------------------------
+
+	describe("sia_detect_changes", () => {
+		it("suggests sia_impact + sia_by_file when files changed", () => {
+			const hints = buildNextSteps("sia_detect_changes", {
+				changedFiles: ["src/a.ts", "src/b.ts"],
+			});
+			const tools = hints.map((h) => h.tool);
+			expect(tools).toContain("sia_impact");
+			expect(tools).toContain("sia_by_file");
+			const bf = hints.find((h) => h.tool === "sia_by_file");
+			expect(bf?.args?.file_path).toBe("src/a.ts");
+		});
+
+		it("returns [] when no files changed", () => {
+			expect(buildNextSteps("sia_detect_changes", { changedFiles: [] })).toEqual([]);
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_index
+	// ---------------------------------------------------------------
+
+	describe("sia_index", () => {
+		it("suggests sia_search when chunks indexed", () => {
+			const hints = buildNextSteps("sia_index", { resultCount: 3 });
+			expect(hints.map((h) => h.tool)).toContain("sia_search");
+		});
+
+		it("returns [] when nothing indexed", () => {
+			expect(buildNextSteps("sia_index", { resultCount: 0 })).toEqual([]);
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_batch_execute
+	// ---------------------------------------------------------------
+
+	describe("sia_batch_execute", () => {
+		it("returns [] on success", () => {
+			expect(buildNextSteps("sia_batch_execute", { hasFailure: false })).toEqual([]);
+		});
+
+		it("suggests sia_doctor on failure", () => {
+			const hints = buildNextSteps("sia_batch_execute", { hasFailure: true });
+			expect(hints.map((h) => h.tool)).toContain("sia_doctor");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_fetch_and_index
+	// ---------------------------------------------------------------
+
+	describe("sia_fetch_and_index", () => {
+		it("suggests sia_search on success", () => {
+			const hints = buildNextSteps("sia_fetch_and_index", { hasFailure: false });
+			expect(hints.map((h) => h.tool)).toContain("sia_search");
+		});
+
+		it("returns [] on failure", () => {
+			expect(buildNextSteps("sia_fetch_and_index", { hasFailure: true })).toEqual([]);
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_flag
+	// ---------------------------------------------------------------
+
+	describe("sia_flag", () => {
+		it("suggests sia_search after a flag", () => {
+			const hints = buildNextSteps("sia_flag", { hasFailure: false });
+			expect(hints.map((h) => h.tool)).toContain("sia_search");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// sia_models
+	// ---------------------------------------------------------------
+
+	describe("sia_models", () => {
+		it("suggests sia_doctor", () => {
+			const hints = buildNextSteps("sia_models", {});
+			expect(hints.map((h) => h.tool)).toContain("sia_doctor");
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// snapshot tools
+	// ---------------------------------------------------------------
+
+	describe("sia_snapshot_list", () => {
+		it("suggests sia_snapshot_restore on the newest entry", () => {
+			const hints = buildNextSteps("sia_snapshot_list", {
+				resultCount: 2,
+				newestBranchName: "main",
+			});
+			const restore = hints.find((h) => h.tool === "sia_snapshot_restore");
+			expect(restore?.args?.branch_name).toBe("main");
+		});
+
+		it("returns [] when no snapshots", () => {
+			expect(buildNextSteps("sia_snapshot_list", { resultCount: 0 })).toEqual([]);
+		});
+	});
+
+	describe("sia_snapshot_restore", () => {
+		it("suggests sia_doctor to verify", () => {
+			const hints = buildNextSteps("sia_snapshot_restore", {});
+			expect(hints.map((h) => h.tool)).toContain("sia_doctor");
+		});
+	});
+
+	describe("sia_snapshot_prune", () => {
+		it("suggests sia_snapshot_list to confirm", () => {
+			const hints = buildNextSteps("sia_snapshot_prune", {});
+			expect(hints.map((h) => h.tool)).toContain("sia_snapshot_list");
+		});
+	});
+});

--- a/tests/unit/mcp/sia-models.test.ts
+++ b/tests/unit/mcp/sia-models.test.ts
@@ -25,15 +25,15 @@ function createMockManager(overrides?: Record<string, unknown>): ModelManager {
 describe("handleSiaModels", () => {
 	it("returns initialization message when modelManager is null", () => {
 		const result = handleSiaModels({ action: "status" }, null);
-		expect(result).toContain("not available");
+		expect(result.text).toContain("not available");
 	});
 
 	it("returns formatted output with tier and attention head phase", () => {
 		const manager = mockModelManager();
 		const result = handleSiaModels({ action: "status" }, manager);
-		expect(result).toContain("Installed tier: T0");
-		expect(result).toContain("Attention head: none");
-		expect(result).toContain("(none installed)");
+		expect(result.text).toContain("Installed tier: T0");
+		expect(result.text).toContain("Attention head: none");
+		expect(result.text).toContain("(none installed)");
 	});
 
 	it("lists installed models with tier, variant, and size", () => {
@@ -61,9 +61,16 @@ describe("handleSiaModels", () => {
 		};
 
 		const result = handleSiaModels({ action: "status" }, manager);
-		expect(result).toContain("Installed tier: T1");
-		expect(result).toContain("bge-small-en-v1.5");
-		expect(result).toContain("int8");
-		expect(result).toContain("48 MB"); // 50M / 1048576 ≈ 48
+		expect(result.text).toContain("Installed tier: T1");
+		expect(result.text).toContain("bge-small-en-v1.5");
+		expect(result.text).toContain("int8");
+		expect(result.text).toContain("48 MB"); // 50M / 1048576 ≈ 48
+	});
+
+	it("populates next_steps with sia_doctor hint", () => {
+		const manager = mockModelManager();
+		const result = handleSiaModels({ action: "status" }, manager);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_doctor");
 	});
 });

--- a/tests/unit/mcp/sia-sync-status.test.ts
+++ b/tests/unit/mcp/sia-sync-status.test.ts
@@ -66,4 +66,22 @@ describe("handleSiaSyncStatus", () => {
 		expect(result.status).toBe("error");
 		expect(result.error).toBe("config file corrupt");
 	});
+
+	it("omits next_steps on normal status", async () => {
+		mockGetConfig.mockReturnValue({
+			sync: { enabled: false, serverUrl: null, developerId: null, syncInterval: 30 },
+		});
+		const result = await handleSiaSyncStatus();
+		expect(result.next_steps).toBeUndefined();
+	});
+
+	it("populates next_steps with sia_doctor on error status", async () => {
+		mockGetConfig.mockImplementation(() => {
+			throw new Error("boom");
+		});
+		const result = await handleSiaSyncStatus();
+		expect(result.status).toBe("error");
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_doctor");
+	});
 });

--- a/tests/unit/mcp/tools/sia-backlinks.test.ts
+++ b/tests/unit/mcp/tools/sia-backlinks.test.ts
@@ -241,4 +241,32 @@ describe("sia_backlinks tool", () => {
 		expect(result.total_count).toBe(0);
 		expect(Object.keys(result.backlinks)).toHaveLength(0);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated when backlinks found
+	// ---------------------------------------------------------------
+
+	it("populates next_steps when backlinks found", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("backlinks-next-steps", tmpDir);
+
+		const target = await insertEntity(db, {
+			type: "CodeEntity",
+			name: "Target",
+			content: "",
+			summary: "",
+		});
+		const caller = await insertEntity(db, {
+			type: "CodeEntity",
+			name: "Caller",
+			content: "",
+			summary: "",
+		});
+		await insertEdge(db, { from_id: caller.id, to_id: target.id, type: "pertains_to" });
+
+		const result = await handleSiaBacklinks(db, { node_id: target.id });
+		expect(result.total_count).toBeGreaterThan(0);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_expand");
+	});
 });

--- a/tests/unit/mcp/tools/sia-batch-execute.test.ts
+++ b/tests/unit/mcp/tools/sia-batch-execute.test.ts
@@ -100,4 +100,36 @@ describe("handleSiaBatchExecute", () => {
 		const throttleResult = await deps.throttle.check(deps.sessionId, "sia_execute");
 		expect(throttleResult.callCount).toBe(3);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps: omitted on success, sia_doctor hint on failure
+	// ---------------------------------------------------------------
+
+	it("omits next_steps when all operations succeed", async () => {
+		const deps = setup();
+		const result = await handleSiaBatchExecute(
+			db,
+			{ operations: [{ type: "execute", code: 'echo "ok"', language: "bash" }] },
+			deps.embedder,
+			deps.throttle,
+			deps.sessionId,
+		);
+		expect(result.results[0].error).toBeUndefined();
+		expect(result.next_steps).toBeUndefined();
+	});
+
+	it("populates next_steps with sia_doctor hint on failure", async () => {
+		const deps = setup();
+		// Invalid op type gets caught & recorded with .error
+		const result = await handleSiaBatchExecute(
+			db,
+			{ operations: [{ type: "search", query: "irrelevant" }] },
+			deps.embedder,
+			deps.throttle,
+			deps.sessionId,
+		);
+		expect(result.results[0].error).toBeDefined();
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_doctor");
+	});
 });

--- a/tests/unit/mcp/tools/sia-by-file.test.ts
+++ b/tests/unit/mcp/tools/sia-by-file.test.ts
@@ -244,4 +244,37 @@ describe("sia_by_file tool", () => {
 		expect(result.entities).toHaveLength(1);
 		expect(result.entities[0]?.id).toBe(activeId);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated on hits
+	// ---------------------------------------------------------------
+
+	it("populates next_steps when entities found", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("by-file-next-steps", tmpDir);
+
+		await insertTestEntity(db, {
+			id: randomUUID(),
+			name: "Next Steps Entity",
+			filePaths: ["src/next.ts"],
+		});
+
+		const result = await handleSiaByFile(db, { file_path: "src/next.ts" });
+		expect(result.next_steps).toBeDefined();
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_search");
+	});
+
+	// ---------------------------------------------------------------
+	// next_steps still populated on zero-hit queries (broader search hint)
+	// ---------------------------------------------------------------
+
+	it("populates next_steps (broader search hint) on empty result", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("by-file-next-steps-empty", tmpDir);
+
+		const result = await handleSiaByFile(db, { file_path: "src/absent.ts" });
+		expect(result.entities).toHaveLength(0);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+	});
 });

--- a/tests/unit/mcp/tools/sia-community.test.ts
+++ b/tests/unit/mcp/tools/sia-community.test.ts
@@ -260,4 +260,20 @@ describe("handleSiaCommunity", () => {
 		const result = await handleSiaCommunity(db, {});
 		expect(result.communities).toHaveLength(3);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated when communities found
+	// ---------------------------------------------------------------
+
+	it("populates next_steps when communities found", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("comm-next-steps", tmpDir);
+
+		await insertCommunity(db, { level: 0, summary: "Auth cluster", member_count: 5 });
+
+		const result = await handleSiaCommunity(db, {});
+		expect(result.communities.length).toBeGreaterThan(0);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_backlinks");
+	});
 });

--- a/tests/unit/mcp/tools/sia-detect-changes.test.ts
+++ b/tests/unit/mcp/tools/sia-detect-changes.test.ts
@@ -136,4 +136,31 @@ describe("sia_detect_changes tool", () => {
 		expect(result.files_changed.length).toBe(0);
 		expect(result.total_entities_affected).toBe(0);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated when files changed
+	// ---------------------------------------------------------------
+
+	it("populates next_steps when files changed", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("dc-next-steps", tmpDir);
+
+		const result = await handleSiaDetectChanges(
+			db,
+			{ scope: "HEAD~1..HEAD" },
+			async () => "M\tsrc/foo.ts\n",
+		);
+		expect(result.files_changed.length).toBeGreaterThan(0);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_impact");
+	});
+
+	it("omits next_steps when no files changed", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("dc-no-changes", tmpDir);
+
+		const result = await handleSiaDetectChanges(db, { scope: "HEAD~1..HEAD" }, async () => "");
+		expect(result.files_changed.length).toBe(0);
+		expect(result.next_steps).toBeUndefined();
+	});
 });

--- a/tests/unit/mcp/tools/sia-doctor.test.ts
+++ b/tests/unit/mcp/tools/sia-doctor.test.ts
@@ -132,4 +132,38 @@ describe("sia_doctor tool", () => {
 		expect(orphanCheck).toBeDefined();
 		expect(orphanCheck?.status).toBe("warn");
 	});
+
+	// -----------------------------------------------------------------------
+	// next_steps: sia_upgrade + /sia-setup on failure; sia_stats when healthy
+	// -----------------------------------------------------------------------
+
+	it("populates next_steps with upgrade/setup hints when any check fails", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		// Force a graph_integrity warn via orphan edge
+		await insertOrphanEdge(db, { fromId: "x", toId: "y" });
+
+		const result = await handleSiaDoctor(db, { checks: ["graph_integrity"] });
+		expect(result.healthy).toBe(false);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		const tools = result.next_steps?.map((s) => s.tool) ?? [];
+		expect(tools).toContain("sia_upgrade");
+		expect(tools).toContain("/sia-setup");
+	});
+
+	it("populates next_steps with sia_stats hint when healthy", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		// fts5 check is deterministic and should pass on a freshly opened DB
+		const result = await handleSiaDoctor(db, { checks: ["fts5"] });
+		if (result.healthy) {
+			expect(result.next_steps?.length).toBeGreaterThan(0);
+			expect(result.next_steps?.map((s) => s.tool)).toContain("sia_stats");
+		} else {
+			// If environment makes fts5 fail, we still test the other branch
+			expect(result.next_steps?.map((s) => s.tool)).toContain("sia_upgrade");
+		}
+	});
 });

--- a/tests/unit/mcp/tools/sia-expand.test.ts
+++ b/tests/unit/mcp/tools/sia-expand.test.ts
@@ -342,4 +342,24 @@ describe("sia_expand tool", () => {
 		expect(result.neighbors).toHaveLength(1);
 		expect(result.neighbors[0]?.id).toBe(idB);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated on successful expand
+	// ---------------------------------------------------------------
+
+	it("populates next_steps on successful expand", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("expand-next-steps", tmpDir);
+
+		const root = randomUUID();
+		const neighbor = randomUUID();
+		await insertTestEntity(db, { id: root, name: "Root" });
+		await insertTestEntity(db, { id: neighbor, name: "Neighbour" });
+		await insertTestEdge(db, { fromId: root, toId: neighbor, type: "relates_to" });
+
+		const result = await handleSiaExpand(db, { entity_id: root });
+		expect(isError(result)).toBe(false);
+		if (isError(result)) return;
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+	});
 });

--- a/tests/unit/mcp/tools/sia-fetch-and-index.test.ts
+++ b/tests/unit/mcp/tools/sia-fetch-and-index.test.ts
@@ -54,4 +54,35 @@ describe("handleSiaFetchAndIndex", () => {
 		expect(result.error).toBeDefined();
 		expect(result.error).toMatch(/HTTP/i);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps omitted on failure (error response)
+	// ---------------------------------------------------------------
+
+	it("omits next_steps when fetch fails", async () => {
+		const mockDb = {
+			execute: async () => ({ rows: [] }),
+			executeMany: async () => {},
+			transaction: async (fn: (db: unknown) => Promise<void>) => fn(mockDb),
+			close: async () => {},
+			rawSqlite: () => null,
+		};
+
+		const mockEmbedder = {
+			embed: async () => new Float32Array(384),
+			embedBatch: async (texts: string[]) => texts.map(() => new Float32Array(384)),
+			close: () => {},
+		};
+
+		const result = await handleSiaFetchAndIndex(
+			mockDb as unknown as import("@/graph/db-interface").SiaDb,
+			{ url: "file:///etc/passwd" },
+			mockEmbedder,
+			"session-test",
+		);
+
+		expect(result.error).toBeDefined();
+		// On failure the handler returns early, before next_steps is attached.
+		expect(result.next_steps).toBeUndefined();
+	});
 });

--- a/tests/unit/mcp/tools/sia-flag.test.ts
+++ b/tests/unit/mcp/tools/sia-flag.test.ts
@@ -208,4 +208,22 @@ describe("sia_flag tool", () => {
 		expect(result).toContain(".");
 		expect(result).toBe(input);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated on successful flag
+	// ---------------------------------------------------------------
+
+	it("populates next_steps on successful flag", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("flag-next-steps", tmpDir);
+
+		const result = await handleSiaFlag(
+			db,
+			{ reason: "needs review" },
+			{ enableFlagging: true, sessionId: "sess-next-steps" },
+		);
+
+		expect(result.flagged).toBe(true);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+	});
 });

--- a/tests/unit/mcp/tools/sia-index.test.ts
+++ b/tests/unit/mcp/tools/sia-index.test.ts
@@ -110,4 +110,23 @@ describe("handleSiaIndex", () => {
 		expect(result.references).toBe(0);
 		expect(result.chunkIds).toHaveLength(0);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated when chunks indexed
+	// ---------------------------------------------------------------
+
+	it("populates next_steps when chunks indexed", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("index-next-steps", tmpDir);
+
+		const result = await handleSiaIndex(
+			db,
+			{ content: "# Heading\nSome content to index here.", source: "test.md" },
+			mockEmbedder,
+			"sess-next",
+		);
+		expect(result.indexed).toBeGreaterThan(0);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_search");
+	});
 });

--- a/tests/unit/mcp/tools/sia-note.test.ts
+++ b/tests/unit/mcp/tools/sia-note.test.ts
@@ -273,4 +273,59 @@ describe("sia_note tool", () => {
 			}),
 		).rejects.toThrow("Referenced entities not found: nonexistent-entity-id-99999");
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated for Decision (includes sia_flag hint)
+	// ---------------------------------------------------------------
+
+	it("populates next_steps with sia_flag hint for Decision kind", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("note-next-steps-decision", tmpDir);
+
+		const target = await insertEntity(db, {
+			type: "CodeEntity",
+			name: "Module",
+			content: "",
+			summary: "",
+		});
+
+		const result = await handleSiaNote(db, {
+			kind: "Decision",
+			name: "Pick X",
+			content: "Picked X for reasons",
+			relates_to: [target.id],
+		});
+
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		const tools = result.next_steps?.map((s) => s.tool) ?? [];
+		expect(tools).toContain("sia_search");
+		expect(tools).toContain("sia_flag");
+	});
+
+	// ---------------------------------------------------------------
+	// next_steps populated for non-Decision (no sia_flag hint)
+	// ---------------------------------------------------------------
+
+	it("populates next_steps without sia_flag hint for non-Decision kinds", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("note-next-steps-convention", tmpDir);
+
+		const target = await insertEntity(db, {
+			type: "CodeEntity",
+			name: "Module2",
+			content: "",
+			summary: "",
+		});
+
+		const result = await handleSiaNote(db, {
+			kind: "Convention",
+			name: "Use foo",
+			content: "Always use foo",
+			relates_to: [target.id],
+		});
+
+		const tools = result.next_steps?.map((s) => s.tool) ?? [];
+		expect(tools).toContain("sia_search");
+		expect(tools).not.toContain("sia_flag");
+	});
 });

--- a/tests/unit/mcp/tools/sia-snapshot-list.test.ts
+++ b/tests/unit/mcp/tools/sia-snapshot-list.test.ts
@@ -112,4 +112,30 @@ describe("sia_snapshot_list tool", () => {
 		expect(result.error).toMatch(/Snapshot list query failed/);
 		expect(result.error).toMatch(/boom from graph layer/);
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps: populated when snapshots exist, omitted when empty
+	// ---------------------------------------------------------------
+
+	it("populates next_steps with sia_snapshot_restore on the newest entry", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		await createBranchSnapshot(db, "main", "hash-main");
+
+		const result = await handleSiaSnapshotList(db);
+		expect(result.snapshots).toHaveLength(1);
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		const restore = result.next_steps?.find((s) => s.tool === "sia_snapshot_restore");
+		expect(restore?.args?.branch_name).toBe(result.snapshots[0].branch_name);
+	});
+
+	it("omits next_steps when no snapshots exist", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		const result = await handleSiaSnapshotList(db);
+		expect(result.snapshots).toHaveLength(0);
+		expect(result.next_steps).toBeUndefined();
+	});
 });

--- a/tests/unit/mcp/tools/sia-snapshot-prune.test.ts
+++ b/tests/unit/mcp/tools/sia-snapshot-prune.test.ts
@@ -44,10 +44,8 @@ describe("sia_snapshot_prune tool", () => {
 			branch_names: ["feature/one", "feature/two"],
 		});
 
-		expect(result).toEqual({
-			pruned: 2,
-			branch_names: ["feature/one", "feature/two"],
-		});
+		expect(result.pruned).toBe(2);
+		expect(result.branch_names).toEqual(["feature/one", "feature/two"]);
 
 		// feature/three is untouched.
 		const { rows } = await db.execute("SELECT branch_name FROM branch_snapshots");
@@ -66,10 +64,8 @@ describe("sia_snapshot_prune tool", () => {
 			branch_names: ["ghost-branch-a", "ghost-branch-b"],
 		});
 
-		expect(result).toEqual({
-			pruned: 0,
-			branch_names: ["ghost-branch-a", "ghost-branch-b"],
-		});
+		expect(result.pruned).toBe(0);
+		expect(result.branch_names).toEqual(["ghost-branch-a", "ghost-branch-b"]);
 	});
 
 	// ---------------------------------------------------------------
@@ -84,7 +80,8 @@ describe("sia_snapshot_prune tool", () => {
 
 		const result = await handleSiaSnapshotPrune(db, { branch_names: [] });
 
-		expect(result).toEqual({ pruned: 0, branch_names: [] });
+		expect(result.pruned).toBe(0);
+		expect(result.branch_names).toEqual([]);
 
 		const { rows } = await db.execute("SELECT COUNT(*) AS cnt FROM branch_snapshots");
 		expect(Number(rows[0].cnt)).toBe(1);
@@ -107,5 +104,18 @@ describe("sia_snapshot_prune tool", () => {
 		// No rows were deleted — validation runs before the DB touch.
 		const { rows } = await db.execute("SELECT COUNT(*) AS cnt FROM branch_snapshots");
 		expect(Number(rows[0].cnt)).toBe(1);
+	});
+
+	// ---------------------------------------------------------------
+	// next_steps: always suggests sia_snapshot_list to confirm
+	// ---------------------------------------------------------------
+
+	it("populates next_steps with sia_snapshot_list to confirm", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		const result = await handleSiaSnapshotPrune(db, { branch_names: [] });
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_snapshot_list");
 	});
 });

--- a/tests/unit/mcp/tools/sia-snapshot-restore.test.ts
+++ b/tests/unit/mcp/tools/sia-snapshot-restore.test.ts
@@ -49,7 +49,8 @@ describe("sia_snapshot_restore tool", () => {
 
 		const result = await handleSiaSnapshotRestore(db, { branch_name: "feature/restore" });
 
-		expect(result).toEqual({ restored: true, branch_name: "feature/restore" });
+		expect(result.restored).toBe(true);
+		expect(result.branch_name).toBe("feature/restore");
 	});
 
 	// ---------------------------------------------------------------
@@ -62,7 +63,8 @@ describe("sia_snapshot_restore tool", () => {
 
 		const result = await handleSiaSnapshotRestore(db, { branch_name: "never-snapshotted" });
 
-		expect(result).toEqual({ restored: false, branch_name: "never-snapshotted" });
+		expect(result.restored).toBe(false);
+		expect(result.branch_name).toBe("never-snapshotted");
 	});
 
 	// ---------------------------------------------------------------
@@ -79,5 +81,18 @@ describe("sia_snapshot_restore tool", () => {
 		await expect(handleSiaSnapshotRestore(db, { branch_name: "   " })).rejects.toThrow(
 			/Invalid snapshot name/,
 		);
+	});
+
+	// ---------------------------------------------------------------
+	// next_steps: always suggests sia_doctor (verify after restore)
+	// ---------------------------------------------------------------
+
+	it("populates next_steps with sia_doctor to verify", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb(randomUUID(), tmpDir);
+
+		const result = await handleSiaSnapshotRestore(db, { branch_name: "any" });
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_doctor");
 	});
 });

--- a/tests/unit/mcp/tools/sia-stats.test.ts
+++ b/tests/unit/mcp/tools/sia-stats.test.ts
@@ -123,4 +123,27 @@ describe("sia_stats tool", () => {
 		expect(result.edges).toEqual({});
 		expect(result.session).toBeUndefined();
 	});
+
+	// ---------------------------------------------------------------
+	// next_steps: /sia-learn on empty graph, sia_doctor otherwise
+	// ---------------------------------------------------------------
+
+	it("populates next_steps with /sia-learn hint on empty graph", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("stats-empty", tmpDir);
+
+		const result = await handleSiaStats(db, {});
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("/sia-learn");
+	});
+
+	it("populates next_steps with sia_doctor hint on non-empty graph", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("stats-populated", tmpDir);
+		await insertTestNode(db, { type: "CodeEntity", name: "X" });
+
+		const result = await handleSiaStats(db, {});
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_doctor");
+	});
 });

--- a/tests/unit/mcp/tools/sia-upgrade.test.ts
+++ b/tests/unit/mcp/tools/sia-upgrade.test.ts
@@ -97,4 +97,30 @@ describe("sia_upgrade tool", () => {
 		expect(result.error).toBeDefined();
 		expect(result.error).toContain("Cannot determine current version");
 	});
+
+	// -----------------------------------------------------------------------
+	// next_steps: sia_doctor on both success (dry_run) and failure
+	// -----------------------------------------------------------------------
+
+	it("populates next_steps with sia_doctor on dry_run (success)", async () => {
+		const gitDir = makeTmp();
+		tmpDirs.push(gitDir);
+		mkdirSync(join(gitDir, ".git"), { recursive: true });
+
+		const db = {} as SiaDb;
+		const result = await handleSiaUpgrade(db, { dry_run: true }, { siaRoot: gitDir });
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_doctor");
+	});
+
+	it("populates next_steps with sia_doctor on failure branch", async () => {
+		const tmpDir = makeTmp();
+		tmpDirs.push(tmpDir);
+
+		const db = {} as SiaDb;
+		const result = await handleSiaUpgrade(db, { dry_run: false }, { siaRoot: tmpDir });
+		expect(result.error).toBeDefined();
+		expect(result.next_steps?.length).toBeGreaterThan(0);
+		expect(result.next_steps?.map((s) => s.tool)).toContain("sia_doctor");
+	});
 });


### PR DESCRIPTION
## Summary

- New `src/mcp/next-steps.ts` helper: `buildNextSteps(toolName, context)` returns `NextStep[]` that chain each response to the next natural tool call.
- Applied across 18 tools (16 weak-trigger + 3 A1 snapshot): `sia_models`, `sia_by_file`, `sia_expand`, `sia_community`, `sia_flag`, `sia_backlinks`, `sia_note`, `sia_index`, `sia_batch_execute`, `sia_fetch_and_index`, `sia_stats`, `sia_doctor`, `sia_upgrade`, `sia_sync_status`, `sia_detect_changes`, `sia_snapshot_{list,restore,prune}`.
- `next_steps` field is OPTIONAL (`next_steps?: NextStep[]`); populated when meaningful, omitted otherwise.
- Response shapes additive except `sia_models` (was bare string → `{ text, next_steps? }`).
- CHANGELOG catches the missed A8 entry (verify-before-completion + brainstorming) that slipped A8's merge.

Closes Phase 5 §5.7 trigger-weakness gap. No version bump — user bumps on publish.

## Test plan

- [x] 35 new tests in `tests/unit/mcp/next-steps.test.ts`
- [x] 18 tool test files each got 1–2 new `next_steps` assertions
- [x] `bun run typecheck` + `lint` clean
- [x] `bun run test` 2101/2101 pass
- [x] `bash scripts/validate-plugin.sh` 9/9
- [x] `bash scripts/count-plugin-components.sh` MCP tools 29 unchanged