### PR TITLE
Phase A6: SessionEnd final consolidation + EpisodeSummary rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sia are documented here. This project adheres to
   `verification-before-completion` discipline with Sia's graph-powered
   past-failure lookup.
 - PreCompact hook now (a) promotes staged entities via `src/graph/staging.ts::promoteStagedEntities()` and (b) emits a `systemMessage` with the top-5 Preferences + top-3 Episodes so the summariser preserves them verbatim. Closes Phase 4 §PreCompact gap. Staging helper is a safe no-op when the schema lacks staging columns (documented in-source).
+- SessionEnd hook performs final staging promotion, aggregates session Signals into EpisodeSummary when ≥ 3 signals fired, and marks `nous_sessions.ended_at`. Closes Phase 4 §SessionEnd gap.
 
 ### Changed
 

--- a/migrations/semantic/013_nous_session_ended_at.sql
+++ b/migrations/semantic/013_nous_session_ended_at.sql
@@ -1,0 +1,11 @@
+-- 013_nous_session_ended_at.sql — Phase A6: SessionEnd final consolidation
+--
+-- Adds an `ended_at` column to `nous_sessions`. Written by the SessionEnd
+-- hook (markSessionEnded) so downstream queries can distinguish sessions
+-- that closed cleanly (ended_at IS NOT NULL) from sessions abandoned mid-run
+-- (ended_at IS NULL, eligible for the stale-session sweep).
+--
+-- Nullable — pre-existing rows and in-progress sessions have no wall-clock
+-- end time. Stored as unix-seconds to match `created_at` / `updated_at`.
+
+ALTER TABLE nous_sessions ADD COLUMN ended_at INTEGER;

--- a/src/hooks/handlers/session-end.ts
+++ b/src/hooks/handlers/session-end.ts
@@ -1,14 +1,34 @@
 // Module: session-end — SessionEnd hook handler
 //
-// Fires when a Claude Code session ends (exit, sigint, or error).
-// Records session statistics and can update the session entity's
-// ended_at timestamp in the graph.
+// Fires when a Claude Code session ends (exit, sigint, or error). Performs
+// the final consolidation pass before session teardown:
 //
-// Returns { status: "processed", nodes_this_session: N } where N is
-// the count of entities created during this session.
+//   1. `promoteStagedEntities()` — one last chance to drain the staging queue
+//      so any provisional Tier-4 rows that gained confidence mid-session get
+//      promoted before the session context is gone. Same helper the PreCompact
+//      hook wires in (Phase A5), reused here.
+//   2. `rollupSessionSignals()` — aggregate the session's Signal nodes into a
+//      single `EpisodeSummary` audit node, but only when COUNT(signals) ≥ 3.
+//      Orthogonal to the Stop hook's Episode node: narrative vs statistics.
+//   3. `markSessionEnded()` — stamp `nous_sessions.ended_at = now` for the
+//      session that is ending so stale-session queries can distinguish clean
+//      exits from abandoned sessions.
+//
+// Fail-safe: every DB call is wrapped. Any failure is logged to stderr and the
+// hook still returns `{ status: 'processed', … }` with whatever counts were
+// collected before the failure. Session teardown must never throw.
+//
+// Legacy response field `nodes_this_session` is preserved for backwards
+// compatibility; Phase A6 adds staging + rollup fields on top.
 
 import type { SiaDb } from "@/graph/db-interface";
+import { promoteStagedEntities } from "@/graph/staging";
 import type { HookEvent, HookResponse } from "@/hooks/types";
+import { rollupSessionSignals } from "@/nous/signal-rollup";
+import { markSessionEnded } from "@/nous/working-memory";
+
+/** Minimum signals before an EpisodeSummary is written (Phase A6 plan §N=3). */
+const SIGNAL_ROLLUP_THRESHOLD = 3;
 
 /**
  * Count the number of entities created during a given session.
@@ -31,17 +51,79 @@ async function countSessionEntities(db: SiaDb, sessionId: string): Promise<numbe
  * Create a SessionEnd hook handler bound to the given graph database.
  *
  * On session end:
- * 1. Counts all entities created during this session (via source_episode).
- * 2. Returns session statistics for observability.
+ * 1. Counts all entities created during this session (via source_episode) —
+ *    legacy field `nodes_this_session` kept for backwards compatibility.
+ * 2. Drains the staging queue via `promoteStagedEntities()`.
+ * 3. Rolls up session Signals into an `EpisodeSummary` node when ≥ 3 fired.
+ * 4. Stamps `nous_sessions.ended_at`.
+ *
+ * Each step is independently try/catch-wrapped so a failure in one does not
+ * stop the others from running. The hook always returns a safe shape.
  */
 export function createSessionEndHandler(db: SiaDb): (event: HookEvent) => Promise<HookResponse> {
 	return async (event: HookEvent): Promise<HookResponse> => {
 		const sessionId = event.session_id;
-		const nodesThisSession = await countSessionEntities(db, sessionId);
+
+		// -------------------------------------------------------------------
+		// Step 1 — legacy entity count (preserved for backwards compat).
+		// -------------------------------------------------------------------
+		let nodesThisSession = 0;
+		try {
+			nodesThisSession = await countSessionEntities(db, sessionId);
+		} catch (err) {
+			process.stderr.write(
+				`[sia:session-end] countSessionEntities failed: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
+		}
+
+		// -------------------------------------------------------------------
+		// Step 2 — final staging drain. Failures logged, counts zeroed.
+		// -------------------------------------------------------------------
+		let stagingPromoted = 0;
+		let stagingKept = 0;
+		let stagingRejected = 0;
+		try {
+			const staging = await promoteStagedEntities(db);
+			stagingPromoted = staging.promoted;
+			stagingKept = staging.kept;
+			stagingRejected = staging.rejected;
+		} catch (err) {
+			process.stderr.write(
+				`[sia:session-end] promoteStagedEntities failed: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
+		}
+
+		// -------------------------------------------------------------------
+		// Step 3 — signal rollup. Only creates EpisodeSummary when ≥ threshold.
+		// -------------------------------------------------------------------
+		let signalRollupCreated = false;
+		try {
+			const rollup = rollupSessionSignals(db, sessionId, SIGNAL_ROLLUP_THRESHOLD);
+			signalRollupCreated = rollup.created;
+		} catch (err) {
+			process.stderr.write(
+				`[sia:session-end] rollupSessionSignals failed: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
+		}
+
+		// -------------------------------------------------------------------
+		// Step 4 — mark session ended. Safe no-op when row already gone.
+		// -------------------------------------------------------------------
+		try {
+			markSessionEnded(db, sessionId);
+		} catch (err) {
+			process.stderr.write(
+				`[sia:session-end] markSessionEnded failed: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
+		}
 
 		return {
 			status: "processed",
 			nodes_this_session: nodesThisSession,
+			staging_promoted: stagingPromoted,
+			staging_kept: stagingKept,
+			staging_rejected: stagingRejected,
+			signal_rollup_created: signalRollupCreated,
 		};
 	};
 }

--- a/src/nous/signal-rollup.ts
+++ b/src/nous/signal-rollup.ts
@@ -1,0 +1,178 @@
+// Module: nous/signal-rollup — SessionEnd: aggregate session Signals → EpisodeSummary
+//
+// Phase A6 helper. At SessionEnd the primary Episode/SubagentEpisode node has
+// already been written by the Stop hook's `writeEpisode()`. This helper adds a
+// second, statistics-focused audit node — an `EpisodeSummary` — that aggregates
+// the Signal nodes produced during the session:
+//
+//   • total signal count, split into discomfort / surprise buckets
+//   • max intensity observed (Signal.confidence is the raw signal score)
+//   • the wall-clock timestamp of the peak signal
+//
+// Only written when COUNT(signals) >= threshold (default 3 per Phase A6 plan).
+// Below threshold the function is a no-op — small sessions have too little
+// statistical weight to warrant a summary node.
+//
+// `EpisodeSummary` is a new `kind` on `graph_nodes`, registered as a
+// bookkeeping kind in `src/nous/types.ts::NOUS_BOOKKEEPING_KINDS` so it is
+// excluded from curiosity-style retrieval alongside `Episode` / `SubagentEpisode`.
+// Separate from `Episode` so downstream consumers can reason about narrative vs
+// statistical audit trails independently.
+
+import { v4 as uuid } from "uuid";
+import type { SiaDb } from "@/graph/db-interface";
+
+/** Default minimum signal count for an EpisodeSummary to be written. */
+export const DEFAULT_ROLLUP_THRESHOLD = 3;
+
+/** Outcome of a rollup pass. */
+export interface RollupResult {
+	/** True iff an EpisodeSummary node was inserted this call. */
+	created: boolean;
+	/** Total Signal nodes observed for the session (captured_by_session_id match). */
+	totalSignals: number;
+	/** Signals whose name starts with `discomfort:` — approval-seeking bucket. */
+	discomfortCount: number;
+	/** Signals whose name starts with `surprise:` — prediction-error bucket. */
+	surpriseCount: number;
+	/** EpisodeSummary node id when created, else null. */
+	summaryNodeId: string | null;
+}
+
+/** Row shape returned by the per-signal SELECT. */
+interface SignalRow {
+	name: string | null;
+	confidence: number | null;
+	created_at: number | null;
+}
+
+/**
+ * Write an `EpisodeSummary` node aggregating Signal statistics for `sessionId`.
+ *
+ * Gated on `COUNT(signals) >= threshold` (default 3). Under threshold the
+ * function returns `{ created: false, … }` without writing. Safe no-op when
+ * the backing DB is not bun-backed (no raw handle available).
+ *
+ * Signal subtype (discomfort vs surprise) is inferred from the `name`
+ * prefix — the existing Signal writers use names like `discomfort:<sid>` and
+ * would write `surprise:<sid>` once the surprise-router lands in Phase 2.
+ *
+ * Body format (pipe-separated, machine-parseable for downstream consumers):
+ *
+ *   Session: <sid>
+ *   Signals: <total> (discomfort: <d>, surprise: <s>)
+ *   Max intensity: <peak>
+ *   Peak at: <unix-ms>
+ */
+export function rollupSessionSignals(
+	db: SiaDb,
+	sessionId: string,
+	threshold: number = DEFAULT_ROLLUP_THRESHOLD,
+): RollupResult {
+	const empty: RollupResult = {
+		created: false,
+		totalSignals: 0,
+		discomfortCount: 0,
+		surpriseCount: 0,
+		summaryNodeId: null,
+	};
+
+	const raw = db.rawSqlite();
+	if (!raw) return empty;
+
+	// Pull the Signal rows captured during this session. `captured_by_session_id`
+	// is the canonical linkage — same column used by the Episode writer.
+	let rows: SignalRow[];
+	try {
+		rows = raw
+			.prepare(
+				`SELECT name, confidence, created_at
+				 FROM graph_nodes
+				 WHERE kind = 'Signal' AND captured_by_session_id = ?`,
+			)
+			.all(sessionId) as SignalRow[];
+	} catch (err) {
+		// Missing table or unexpected error — never break the hook.
+		process.stderr.write(
+			`[sia:signal-rollup] query failed: ${err instanceof Error ? err.message : String(err)}\n`,
+		);
+		return empty;
+	}
+
+	const totalSignals = rows.length;
+	if (totalSignals < threshold) {
+		return { ...empty, totalSignals };
+	}
+
+	let discomfortCount = 0;
+	let surpriseCount = 0;
+	let maxIntensity = 0;
+	let peakAt = 0;
+
+	for (const row of rows) {
+		const name = row.name ?? "";
+		if (name.startsWith("discomfort:")) {
+			discomfortCount++;
+		} else if (name.startsWith("surprise:")) {
+			surpriseCount++;
+		}
+
+		const intensity = typeof row.confidence === "number" ? row.confidence : 0;
+		if (intensity > maxIntensity) {
+			maxIntensity = intensity;
+			peakAt = row.created_at ?? 0;
+		}
+	}
+
+	const now = Date.now();
+	const id = uuid();
+	const name = `EpisodeSummary:${sessionId}`;
+	const content = [
+		`Session: ${sessionId}`,
+		`Signals: ${totalSignals} (discomfort: ${discomfortCount}, surprise: ${surpriseCount})`,
+		`Max intensity: ${maxIntensity.toFixed(3)}`,
+		`Peak at: ${peakAt}`,
+	].join("\n");
+	const summary = `Session ${sessionId}: ${totalSignals} signals (d:${discomfortCount}/s:${surpriseCount}), peak ${maxIntensity.toFixed(2)}`;
+
+	try {
+		raw
+			.prepare(
+				`INSERT INTO graph_nodes (
+					id, type, name, content, summary,
+					tags, file_paths,
+					trust_tier, confidence, base_confidence,
+					importance, base_importance,
+					access_count, edge_count,
+					last_accessed, created_at, t_created,
+					visibility, created_by,
+					session_id, kind,
+					captured_by_session_id, captured_by_session_type
+				) VALUES (
+					?, 'EpisodeSummary', ?, ?, ?,
+					'[]', '[]',
+					2, 1.0, 1.0,
+					0.5, 0.5,
+					0, 0,
+					?, ?, ?,
+					'private', 'nous',
+					?, 'EpisodeSummary',
+					?, ?
+				)`,
+			)
+			.run(id, name, content, summary, now, now, now, sessionId, sessionId, "primary");
+	} catch (err) {
+		process.stderr.write(
+			`[sia:signal-rollup] insert failed: ${err instanceof Error ? err.message : String(err)}\n`,
+		);
+		return { ...empty, totalSignals };
+	}
+
+	return {
+		created: true,
+		totalSignals,
+		discomfortCount,
+		surpriseCount,
+		summaryNodeId: id,
+	};
+}

--- a/src/nous/types.ts
+++ b/src/nous/types.ts
@@ -70,6 +70,7 @@ export const DEFAULT_SESSION_STATE: NousSessionState = {
 export const NOUS_BOOKKEEPING_KINDS = [
 	"Episode",
 	"SubagentEpisode",
+	"EpisodeSummary",
 	"Signal",
 	"Concern",
 	"Preference",

--- a/src/nous/working-memory.ts
+++ b/src/nous/working-memory.ts
@@ -70,6 +70,28 @@ export function deleteSession(db: SiaDb, sessionId: string): void {
 	raw(db).prepare("DELETE FROM nous_sessions WHERE session_id = ?").run(sessionId);
 }
 
+/**
+ * Mark a session as ended by setting `nous_sessions.ended_at = now`.
+ *
+ * Returns `true` when the row existed and was updated, `false` when no row
+ * matched `session_id` (safe no-op — the row may have already been pruned
+ * by `cleanStaleSessions`, deleted by the Stop hook's `writeEpisode`, or
+ * never written if Nous was disabled).
+ *
+ * Stored as unix-seconds to match `created_at` / `updated_at`. The column
+ * is added by migration `013_nous_session_ended_at.sql`.
+ */
+export function markSessionEnded(
+	db: SiaDb,
+	sessionId: string,
+	now: number = Math.floor(Date.now() / 1000),
+): boolean {
+	const result = raw(db)
+		.prepare("UPDATE nous_sessions SET ended_at = ?, updated_at = ? WHERE session_id = ?")
+		.run(now, now, sessionId);
+	return (result.changes ?? 0) > 0;
+}
+
 /** Remove sessions whose last update is older than one hour. */
 export function cleanStaleSessions(db: SiaDb): void {
 	const cutoff = Math.floor(Date.now() / 1000) - 3600;

--- a/tests/unit/hooks/handlers/session-lifecycle.test.ts
+++ b/tests/unit/hooks/handlers/session-lifecycle.test.ts
@@ -12,6 +12,7 @@ import { createPreCompactHandler } from "@/hooks/handlers/pre-compact";
 import { createSessionEndHandler } from "@/hooks/handlers/session-end";
 import { buildSessionContext, formatSessionContext } from "@/hooks/handlers/session-start";
 import type { HookEvent } from "@/hooks/types";
+import { upsertSession } from "@/nous/working-memory";
 
 function makeTmp(): string {
 	const dir = join(tmpdir(), `sia-test-${randomUUID()}`);
@@ -624,5 +625,246 @@ describe("createSessionEndHandler", () => {
 		const result = await handler(event);
 		expect(result.status).toBe("processed");
 		expect(result.nodes_this_session).toBe(0);
+	});
+
+	// -----------------------------------------------------------------------
+	// Phase A6 — final consolidation (staging drain + signal rollup + mark ended).
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Directly write a Signal graph_node scoped to `sessionId`. Bypasses the
+	 * discomfort-signal pipeline so tests can control signal count / shape.
+	 */
+	function insertSignalNode(
+		siaDb: SiaDb,
+		sessionId: string,
+		subtype: "discomfort" | "surprise",
+		score: number,
+		createdAt: number,
+	): void {
+		const raw = siaDb.rawSqlite();
+		if (!raw) throw new Error("test fixture requires bun:sqlite-backed SiaDb");
+		raw
+			.prepare(
+				`INSERT INTO graph_nodes (
+					id, type, name, content, summary,
+					tags, file_paths,
+					trust_tier, confidence, base_confidence,
+					importance, base_importance,
+					access_count, edge_count,
+					last_accessed, created_at, t_created,
+					visibility, created_by,
+					kind,
+					captured_by_session_id, captured_by_session_type
+				) VALUES (
+					?, 'Signal', ?, ?, ?,
+					'[]', '[]',
+					2, ?, ?,
+					0.5, 0.5,
+					0, 0,
+					?, ?, ?,
+					'private', 'nous',
+					'Signal',
+					?, 'primary'
+				)`,
+			)
+			.run(
+				randomUUID(),
+				`${subtype}:${sessionId}`,
+				`${subtype} signal in session ${sessionId}`,
+				`${subtype} score ${score}`,
+				score,
+				score,
+				createdAt,
+				createdAt,
+				createdAt,
+				sessionId,
+			);
+	}
+
+	it("(a) 0 signals + 0 staged → counts present, no rollup, staging zero", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("session-end-a6-empty", tmpDir);
+
+		const sessionId = "a6-empty";
+		upsertSession(db, {
+			session_id: sessionId,
+			parent_session_id: null,
+			session_type: "primary",
+			state: {
+				driftScore: 0,
+				preferenceNodeIds: [],
+				currentCallSignificance: 0,
+				surpriseCount: 0,
+				nousModifyBlocked: false,
+				discomfortRunningScore: 0,
+				toolCallCount: 0,
+				sessionStartedAt: Math.floor(Date.now() / 1000),
+			},
+			created_at: Math.floor(Date.now() / 1000),
+			updated_at: Math.floor(Date.now() / 1000),
+		});
+
+		const handler = createSessionEndHandler(db);
+		const result = await handler(
+			baseEvent({ hook_event_name: "SessionEnd", session_id: sessionId }),
+		);
+
+		expect(result.status).toBe("processed");
+		expect(result.nodes_this_session).toBe(0);
+		expect(result.staging_promoted).toBe(0);
+		expect(result.staging_kept).toBe(0);
+		expect(result.staging_rejected).toBe(0);
+		expect(result.signal_rollup_created).toBe(false);
+
+		// No EpisodeSummary written below the 3-signal threshold.
+		const raw = db.rawSqlite();
+		if (!raw) throw new Error("test requires bun:sqlite");
+		const row = raw
+			.prepare(
+				"SELECT COUNT(*) as cnt FROM graph_nodes WHERE kind = 'EpisodeSummary' AND captured_by_session_id = ?",
+			)
+			.get(sessionId) as { cnt: number };
+		expect(row.cnt).toBe(0);
+
+		// ended_at was stamped on the existing nous_sessions row.
+		const sessionRow = raw
+			.prepare("SELECT ended_at FROM nous_sessions WHERE session_id = ?")
+			.get(sessionId) as { ended_at: number | null } | undefined;
+		expect(sessionRow).toBeDefined();
+		expect(sessionRow?.ended_at).not.toBeNull();
+	});
+
+	it("(b) 5 signals → EpisodeSummary node written, signal_rollup_created = true", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("session-end-a6-rollup", tmpDir);
+
+		const sessionId = "a6-rollup";
+		const now = Date.now();
+		insertSignalNode(db, sessionId, "discomfort", 0.6, now - 4000);
+		insertSignalNode(db, sessionId, "discomfort", 0.75, now - 3000);
+		insertSignalNode(db, sessionId, "discomfort", 0.9, now - 2000);
+		insertSignalNode(db, sessionId, "surprise", 0.5, now - 1000);
+		insertSignalNode(db, sessionId, "surprise", 0.8, now);
+
+		const handler = createSessionEndHandler(db);
+		const result = await handler(
+			baseEvent({ hook_event_name: "SessionEnd", session_id: sessionId }),
+		);
+
+		expect(result.status).toBe("processed");
+		expect(result.signal_rollup_created).toBe(true);
+
+		const raw = db.rawSqlite();
+		if (!raw) throw new Error("test requires bun:sqlite");
+		const summaryRow = raw
+			.prepare(
+				"SELECT name, content, summary FROM graph_nodes WHERE kind = 'EpisodeSummary' AND captured_by_session_id = ?",
+			)
+			.get(sessionId) as { name: string; content: string; summary: string } | undefined;
+
+		expect(summaryRow).toBeDefined();
+		expect(summaryRow?.name).toBe(`EpisodeSummary:${sessionId}`);
+		expect(summaryRow?.content).toContain("Signals: 5 (discomfort: 3, surprise: 2)");
+		// Max intensity should be the discomfort-peak of 0.9 (> surprise peak 0.8).
+		expect(summaryRow?.content).toContain("Max intensity: 0.900");
+	});
+
+	it("(c) staged entity above confidence threshold → promoted", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("session-end-a6-staging", tmpDir);
+
+		await insertStagedFact(db, {
+			proposed_type: "Convention",
+			proposed_name: "A6 promote",
+			proposed_content: "A convention captured in the session that survived confirmatory signals.",
+			trust_tier: 4,
+			raw_confidence: 0.92,
+		});
+		await insertStagedFact(db, {
+			proposed_type: "Concept",
+			proposed_name: "A6 keep",
+			proposed_content: "Something tentative.",
+			trust_tier: 4,
+			raw_confidence: 0.4,
+		});
+
+		const handler = createSessionEndHandler(db);
+		const result = await handler(
+			baseEvent({ hook_event_name: "SessionEnd", session_id: "a6-staging" }),
+		);
+
+		expect(result.status).toBe("processed");
+		expect(result.staging_promoted).toBe(1);
+		expect(result.staging_kept).toBe(1);
+		expect(result.staging_rejected).toBe(0);
+	});
+
+	it("(d) staging failure → caught, stderr logged, hook still returns processed", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("session-end-a6-staging-failure", tmpDir);
+
+		// Stage a clean high-confidence fact so the helper enters the write path.
+		await insertStagedFact(db, {
+			proposed_type: "Convention",
+			proposed_name: "Clean fact",
+			proposed_content: "A convention captured from normal session dialog with full support.",
+			trust_tier: 4,
+			raw_confidence: 0.95,
+		});
+
+		const originalExecute = db.execute.bind(db);
+		const execSpy = vi
+			.spyOn(db, "execute")
+			.mockImplementation(async (sql: string, params?: unknown[]) => {
+				const up = sql.trim().toUpperCase();
+				const isWrite = up.startsWith("UPDATE") || up.startsWith("INSERT");
+				const touchesStagingOrGraph = sql.includes("memory_staging") || sql.includes("graph_nodes");
+				if (isWrite && touchesStagingOrGraph) {
+					throw new Error("simulated staging write failure");
+				}
+				return originalExecute(sql, params);
+			});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+		try {
+			const handler = createSessionEndHandler(db);
+			const result = await handler(
+				baseEvent({ hook_event_name: "SessionEnd", session_id: "a6-fail" }),
+			);
+
+			expect(result.status).toBe("processed");
+			// Staging counts default to zero on failure — hook still returns a safe shape.
+			expect(result.staging_promoted).toBe(0);
+
+			const errCalls = stderrSpy.mock.calls
+				.map((c) => String(c[0]))
+				.filter((s) => s.includes("sia:session-end") || s.includes("sia:staging"));
+			expect(errCalls.length).toBeGreaterThanOrEqual(1);
+		} finally {
+			execSpy.mockRestore();
+			stderrSpy.mockRestore();
+		}
+	});
+
+	it("(e) session_id not in nous_sessions → safe no-op, no throw", async () => {
+		tmpDir = makeTmp();
+		db = openGraphDb("session-end-a6-no-session", tmpDir);
+
+		const handler = createSessionEndHandler(db);
+		const result = await handler(
+			baseEvent({ hook_event_name: "SessionEnd", session_id: "never-started" }),
+		);
+
+		expect(result.status).toBe("processed");
+		expect(result.signal_rollup_created).toBe(false);
+
+		// No nous_sessions row exists; markSessionEnded was a safe no-op.
+		const raw = db.rawSqlite();
+		if (!raw) throw new Error("test requires bun:sqlite");
+		const row = raw
+			.prepare("SELECT COUNT(*) as cnt FROM nous_sessions WHERE session_id = ?")
+			.get("never-started") as { cnt: number };
+		expect(row.cnt).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

- `session-end.ts` extends from single `COUNT(*)` to a 4-step final consolidation: count → `promoteStagedEntities` → `rollupSessionSignals` → `markSessionEnded`.
- New `src/nous/signal-rollup.ts` aggregates session Signals into an `EpisodeSummary` when ≥ 3 signals fired. Separate kind; added to `NOUS_BOOKKEEPING_KINDS`.
- Migration `013_nous_session_ended_at.sql` adds nullable `ended_at INTEGER` column.
- Each step try/catch'd independently; hook returns safe shape on failure; `[sia:session-end]` stderr prefix on errors.
- Backwards-compatible: `nodes_this_session` preserved; new fields (`staging_promoted`, `staging_kept`, `staging_rejected`, `signal_rollup_created`) additive.

Reuses `promoteStagedEntities` from Phase A5 (no duplication).

Closes Phase 4 §SessionEnd gap. No version bump.

## Test plan

- [x] 5 new test cases (empty, 5-signal rollup, staging promotion, staging failure caught, unknown session-id no-op)
- [x] `bun run typecheck` + `lint` + `test` 2149/2150 pass (pre-existing `isWorktree` only)
- [x] `bash scripts/validate-plugin.sh` 9/9