### PR TITLE
Phase B2: commit-capture dispatch hint + 15 utility-skill rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sia are documented here. This project adheres to
   "You MUST use this before any creative work…". Body unchanged.
 - augment-hook PreToolUse subscriber gains an LRU(32) cache + <3-char query skip (Phase 4 §4.4 cost mitigation). post-tool-use-handler skips TrackA for files >500 KB or binary content. preference-seeder folded into self-monitor as an internal step; SessionStart subscriber count drops 15 → 14 at the design level.
 - Consolidated 10 narrow skills into 4 merged skills with subcommand flags: `sia-pm` (sprint-summary/risk-dashboard/decision-log), `sia-export` (json/markdown/import), `sia-qa` (coverage/flaky/full), `sia-health` (stats+status). Skills 48 → 42; commands 40 → 42 (only `stats.md` + `status.md` existed as command shims among the targeted set, per the 1.2.1 pruning rule). Playbooks + docs updated.
+- Rewrote 15 utility-cluster skill descriptions with superpowers-style "Use when X / before Y" triggers (`sia-augment`, `sia-compare`, `sia-digest`, `sia-doctor`, `sia-freshness`, `sia-history`, `sia-index`, `sia-prune`, `sia-reindex`, `sia-sync`, `sia-team`, `sia-tour`, `sia-upgrade`, `sia-visualize-live`, `sia-workspace`). Added PostToolUse `Bash` subscriber that emits a knowledge-capture hint on successful `git commit`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Sia gives your agent a typed, temporal, ontology-enforced knowledge graph that c
 /plugin install sia@sia-plugins
 ```
 
-This registers all 29 MCP tools, 42 skills, 26 agents, 9 hook entries across 7 event types, and CLAUDE.md behavioral directives in one step.
+This registers all 29 MCP tools, 42 skills, 26 agents, 10 hook entries across 7 event types, and CLAUDE.md behavioral directives in one step.
 
 > **Coming soon:** Once Sia is accepted into the official Anthropic marketplace, installation will simplify to `/plugin install sia@claude-plugins-official`.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -44,6 +44,17 @@
 						"timeout": 10000
 					}
 				]
+			},
+			{
+				"_comment": "PostToolUse(Bash) subscriber — emits a systemMessage recommending @sia-knowledge-capture dispatch when a successful (non-amend) `git commit` is detected. Hooks cannot dispatch agents directly; this nudges the human/agent to do so. See src/hooks/handlers/commit-capture-dispatch.ts.",
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "${CLAUDE_PLUGIN_ROOT}/scripts/commit-capture-dispatch.sh",
+						"timeout": 3000
+					}
+				]
 			}
 		],
 		"Stop": [

--- a/scripts/commit-capture-dispatch.sh
+++ b/scripts/commit-capture-dispatch.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# PostToolUse hook — emits a systemMessage recommending
+# @sia-knowledge-capture dispatch when a successful (non-amend)
+# `git commit` is detected on the Bash tool.
+#
+# stderr is redirected to the shared hooks log so diagnostics are
+# preserved for debugging.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+
+source "$PLUGIN_ROOT/scripts/ensure-runtime.sh" "$PLUGIN_ROOT"
+
+SIA_LOG_DIR="${CLAUDE_PLUGIN_DATA:-${HOME}/.sia}/logs"
+mkdir -p "$SIA_LOG_DIR"
+
+exec bun run "$PLUGIN_ROOT/src/hooks/plugin-commit-capture-dispatch.ts" 2>>"${SIA_LOG_DIR}/hooks.log"

--- a/skills/sia-augment/SKILL.md
+++ b/skills/sia-augment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-augment
-description: Toggle automatic graph-context enrichment of Grep/Glob/Bash tool results. Use when the user asks to enable/disable augmentation, when augmented output is noisy or distracting, or when debugging the PreToolUse augment-hook behavior.
+description: Use when you want Grep/Glob/Bash calls auto-enriched with graph context, or before disabling enrichment that is making tool output too noisy. Toggles the PreToolUse augment-hook via `.sia-graph/augment-enabled`.
 ---
 
 # SIA Auto-Augmentation Toggle

--- a/skills/sia-compare/SKILL.md
+++ b/skills/sia-compare/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-compare
-description: Compares knowledge graph state between two time points — shows what was added, invalidated, and archived. Use when investigating what changed in the graph, reviewing temporal diffs, or debugging knowledge evolution.
+description: Use when auditing what changed in the graph between two points in time — shows added, invalidated, and archived entities. Pair with `/sia-history` when you need narrative context around the diff.
 ---
 
 # SIA Compare

--- a/skills/sia-digest/SKILL.md
+++ b/skills/sia-digest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-digest
-description: Generates a daily knowledge digest summarizing recent decisions, bugs, conventions, and changes captured by SIA. Use at the start of a session, for daily standups, or when the user asks what changed recently.
+description: Use at daily standup, at sprint close, or on Monday morning to catch up on the weekend's captured decisions, bugs, and conventions. Summarises a rolling 24-hour window by default.
 ---
 
 # SIA Digest

--- a/skills/sia-doctor/SKILL.md
+++ b/skills/sia-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-doctor
-description: Runs SIA system health diagnostics — checks databases, providers, tree-sitter, embeddings, and connectivity. Use when SIA tools return errors, knowledge seems missing, or the user reports SIA issues.
+description: Use when Sia tools return errors, after a failed install, or as the first step when something feels wrong with the memory system. Runs full diagnostics on databases, providers, tree-sitter, embeddings, and hook registration before you escalate.
 ---
 
 # SIA Doctor

--- a/skills/sia-freshness/SKILL.md
+++ b/skills/sia-freshness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-freshness
-description: Generates a freshness report for the SIA knowledge graph — identifies stale, rotten, and fresh entities. Use when checking knowledge quality, before pruning, or when results seem outdated.
+description: Use before release planning, after a major refactor, or before `/sia-prune` — reports the fresh/stale/rotten entity breakdown with confidence scores so you know what the graph still trusts.
 ---
 
 # SIA Freshness

--- a/skills/sia-history/SKILL.md
+++ b/skills/sia-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-history
-description: Explores how the knowledge graph evolved over time with temporal filtering. Use when reviewing recent decisions, tracking knowledge evolution, or investigating when something was captured.
+description: Use when tracing how a decision, convention, or entity evolved over time — temporal walk of the graph with since/until/type/file filters. Pair with `/sia-compare` when you want the diff between two points rather than the narrative.
 ---
 
 # SIA History

--- a/skills/sia-index/SKILL.md
+++ b/skills/sia-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-index
-description: Indexes external content into SIA's knowledge graph — markdown, URLs, and documents with automatic chunking. Use when adding documentation, design docs, or external references to the graph.
+description: Use when external markdown, URLs, or design docs need to flow into the graph as citeable evidence — batch-indexes content into `ContentChunk` nodes with automatic chunking so future `sia_search` calls can surface them.
 ---
 
 # SIA Index

--- a/skills/sia-prune/SKILL.md
+++ b/skills/sia-prune/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-prune
-description: Removes archived entities from the SIA knowledge graph to reduce database size. Use when the graph grows large, after freshness reports show many stale entities, or for periodic maintenance.
+description: Use when graph database size or search latency is growing uncomfortable, or after `/sia-freshness` flags many rotten entities. Hard-deletes archived (not invalidated) entities to reclaim space; always runs with `--dry-run` first.
 ---
 
 # SIA Prune

--- a/skills/sia-reindex/SKILL.md
+++ b/skills/sia-reindex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-reindex
-description: Re-indexes the repository with tree-sitter to update SIA's knowledge graph with current code structure. Use after significant refactoring, file renames, or when code entities seem out of date.
+description: Use after a major refactor, mass file rename, or tree-sitter grammar upgrade — triggers a full re-index of the repo's AST-derived entities. Reach for this when incremental reindex isn't enough and you want the walker from scratch.
 ---
 
 # SIA Reindex

--- a/skills/sia-sync/SKILL.md
+++ b/skills/sia-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-sync
-description: Pushes or pulls SIA knowledge to/from the team sync server. Use when sharing knowledge with teammates, syncing after a long offline period, or receiving others' captured knowledge.
+description: Use when pushing/pulling team graph diffs mid-session — handles conflict detection and merges via `conflict_group_id`. Normal sync happens on session start/end; reach for this skill only when you need to cross the boundary manually.
 ---
 
 # SIA Manual Sync

--- a/skills/sia-team/SKILL.md
+++ b/skills/sia-team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-team
-description: Manages SIA team sync — joining servers, checking status, or leaving teams. Use when setting up team knowledge sharing, checking sync health, or managing team membership.
+description: Use when joining a new team sync server, checking sync health, or leaving a team — manages the team-collaboration surface (`join`, `status`, `leave`). Start here before `/sia-sync`; this skill owns credentials, that skill owns the transfer.
 ---
 
 # SIA Team Sync Management

--- a/skills/sia-tour/SKILL.md
+++ b/skills/sia-tour/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-tour
-description: Provides an interactive guided tour of the knowledge graph — architecture, decisions, conventions, and known issues. Use for onboarding, exploring what SIA knows, or getting oriented in a new project.
+description: Use when onboarding a new teammate or when you yourself have been away from the repo for weeks — interactive architectural tour that walks module clusters, key decisions, conventions, and known bugs drawn from the graph.
 ---
 
 # SIA Graph Tour

--- a/skills/sia-upgrade/SKILL.md
+++ b/skills/sia-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-upgrade
-description: Self-updates SIA to the latest version via npm, git, or binary strategies. Use when a new SIA version is available or when the user asks to upgrade.
+description: Use when a newer Sia version is available or CHANGELOG shows a needed fix — self-updates via npm/git/binary with rollback if a migration fails. Follow with `/sia-doctor` to confirm the new version is healthy.
 ---
 
 # SIA Upgrade

--- a/skills/sia-visualize-live/SKILL.md
+++ b/skills/sia-visualize-live/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-visualize-live
-description: Launches an interactive browser-based knowledge graph visualizer for exploring entities, dependencies, and communities. Use when the user wants to visually explore the graph or understand module relationships.
+description: Use when the static `/sia-visualize` HTML isn't interactive enough — launches the browser-based explorer with graph, timeline, dependency, and community views backed by live graph data.
 ---
 
 # SIA Live Visualizer

--- a/skills/sia-workspace/SKILL.md
+++ b/skills/sia-workspace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sia-workspace
-description: Manages SIA workspaces for cross-repo knowledge sharing — creating workspaces, adding repos, and detecting API contracts. Use when working across multiple repositories or setting up shared knowledge.
+description: Use when working across multiple repos that share an API contract or domain model — manages the cross-repo workspace that lets `sia_search({ workspace: true })` reach across them. Subcommands: `create`, `list`, `add`, `remove`, `show`.
 ---
 
 # SIA Workspace

--- a/src/hooks/handlers/commit-capture-dispatch.ts
+++ b/src/hooks/handlers/commit-capture-dispatch.ts
@@ -1,0 +1,111 @@
+// Module: commit-capture-dispatch — PostToolUse(Bash) subscriber
+//
+// Emits a `systemMessage` nudge that recommends dispatching the
+// `@sia-knowledge-capture` agent when the agent just ran a successful
+// `git commit` (non-amend) via the Bash tool. Hooks cannot dispatch
+// agents directly — this writes a hint for the human/agent to action.
+//
+// Gate conditions (ALL must hold):
+//   1. tool_name === "Bash"
+//   2. tool_input.command matches /\bgit\s+commit\b/
+//   3. the command is NOT a `--amend` (amends rewrite the same commit)
+//   4. exit code (when present) is 0
+//
+// Any failure of the above returns `{ status: "skipped" }` without a
+// systemMessage — knowledge capture should not be nagged on status/log
+// calls, failed commits, or commit amends.
+
+import type { HookEvent, HookHandler, HookResponse } from "@/hooks/types";
+
+/** Pattern that detects `git commit` invocations (not status/log/diff). */
+const GIT_COMMIT_RE = /\bgit\s+commit\b/;
+
+/**
+ * Pattern that detects `--amend` in a commit command. `--amend` rewrites
+ * the existing commit in place, so re-dispatching knowledge capture would
+ * double-capture the same change.
+ */
+const AMEND_RE = /\s--amend(?:=|\s|$)/;
+
+/**
+ * systemMessage emitted on a successful non-amend `git commit`. Deliberately
+ * short — it's a prompt, not a full instruction. The recipient (human or
+ * agent) is expected to know what `@sia-knowledge-capture` does.
+ */
+export const COMMIT_CAPTURE_HINT =
+	"Git commit detected. Consider dispatching @sia-knowledge-capture to capture decisions/bugs from this change.";
+
+/**
+ * Result of a gate evaluation. Separated from the handler so tests can
+ * exercise the classifier without constructing a full HookEvent.
+ */
+export interface CommitDetection {
+	isCommit: boolean;
+	isAmend: boolean;
+	exitOk: boolean;
+	/** True iff we should emit the hint. Equivalent to isCommit && !isAmend && exitOk. */
+	shouldDispatch: boolean;
+}
+
+/**
+ * Inspect a Bash command + exit code and decide whether a commit-capture
+ * hint is warranted. Pure function; safe to unit test directly.
+ */
+export function detectGitCommit(command: string, exitCode: number): CommitDetection {
+	const isCommit = GIT_COMMIT_RE.test(command);
+	const isAmend = AMEND_RE.test(command);
+	const exitOk = exitCode === 0;
+	return {
+		isCommit,
+		isAmend,
+		exitOk,
+		shouldDispatch: isCommit && !isAmend && exitOk,
+	};
+}
+
+/** Safely read `tool_input.command` as a string. */
+function readCommand(event: HookEvent): string {
+	const cmd = event.tool_input?.command;
+	return typeof cmd === "string" ? cmd : "";
+}
+
+/** Safely read `tool_input.exit_code` as a number, defaulting to 0. */
+function readExitCode(event: HookEvent): number {
+	const raw = event.tool_input?.exit_code;
+	if (typeof raw === "number") return raw;
+	if (typeof raw === "string") {
+		const parsed = Number.parseInt(raw, 10);
+		return Number.isNaN(parsed) ? 0 : parsed;
+	}
+	return 0;
+}
+
+/**
+ * Create a PostToolUse(Bash) handler that emits a systemMessage on
+ * successful non-amend `git commit` commands. The handler is a no-op
+ * for non-Bash tools and for commands that don't match the commit gate.
+ */
+export function createCommitCaptureDispatchHandler(): HookHandler {
+	return async (event: HookEvent): Promise<HookResponse> => {
+		if (event.tool_name !== "Bash") {
+			return { status: "skipped" };
+		}
+
+		const command = readCommand(event);
+		if (!command) {
+			return { status: "skipped" };
+		}
+
+		const exitCode = readExitCode(event);
+		const detection = detectGitCommit(command, exitCode);
+
+		if (!detection.shouldDispatch) {
+			return { status: "skipped" };
+		}
+
+		return {
+			status: "processed",
+			systemMessage: COMMIT_CAPTURE_HINT,
+		};
+	};
+}

--- a/src/hooks/plugin-commit-capture-dispatch.ts
+++ b/src/hooks/plugin-commit-capture-dispatch.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+// Plugin hook wrapper: PostToolUse(Bash) → commit-capture-dispatch
+//
+// Reads the Claude Code PostToolUse event from stdin, invokes the
+// commit-capture-dispatch handler, writes the response (potentially
+// including a systemMessage) to stdout. Any error is logged to stderr
+// and the hook exits 0 so Claude Code is never blocked by this
+// subscriber.
+
+import { createCommitCaptureDispatchHandler } from "@/hooks/handlers/commit-capture-dispatch";
+import { parsePluginHookEvent, readStdin } from "@/hooks/plugin-common";
+
+async function main() {
+	try {
+		const input = await readStdin();
+		if (!input.trim()) return;
+
+		const event = parsePluginHookEvent(input);
+		const handler = createCommitCaptureDispatchHandler();
+		const result = await handler(event);
+
+		// Only write a response when we actually emit something — Claude
+		// Code treats an empty stdout as "no hook output" which is exactly
+		// the right signal for the skipped case.
+		if (result.systemMessage) {
+			process.stdout.write(JSON.stringify(result));
+		}
+	} catch (err) {
+		process.stderr.write(`sia commit-capture-dispatch hook error: ${err}\n`);
+		process.exit(0);
+	}
+}
+
+main();

--- a/tests/unit/hooks/handlers/commit-capture-dispatch.test.ts
+++ b/tests/unit/hooks/handlers/commit-capture-dispatch.test.ts
@@ -1,0 +1,162 @@
+// tests/unit/hooks/handlers/commit-capture-dispatch.test.ts
+//
+// Covers the PostToolUse(Bash) commit-capture-dispatch subscriber:
+//   - git commit detected → systemMessage present
+//   - git status (not commit) → no systemMessage
+//   - git commit --amend → no systemMessage
+//   - non-zero exit code → no systemMessage
+//   - non-Bash tool → no systemMessage
+//   - missing tool_input → no systemMessage
+//
+// The handler has no side-effects (no db, no fs) — all tests are pure.
+
+import { describe, expect, it } from "vitest";
+import {
+	COMMIT_CAPTURE_HINT,
+	createCommitCaptureDispatchHandler,
+	detectGitCommit,
+} from "@/hooks/handlers/commit-capture-dispatch";
+import type { HookEvent } from "@/hooks/types";
+
+function baseEvent(overrides: Partial<HookEvent> = {}): HookEvent {
+	return {
+		session_id: "test-session",
+		transcript_path: "/tmp/transcript.jsonl",
+		cwd: "/tmp/project",
+		hook_event_name: "PostToolUse",
+		tool_name: "Bash",
+		...overrides,
+	};
+}
+
+describe("detectGitCommit", () => {
+	it("detects a plain `git commit -m` invocation as a commit", () => {
+		const d = detectGitCommit('git commit -m "feat: add thing"', 0);
+		expect(d.isCommit).toBe(true);
+		expect(d.isAmend).toBe(false);
+		expect(d.shouldDispatch).toBe(true);
+	});
+
+	it("does not treat `git status` as a commit", () => {
+		const d = detectGitCommit("git status", 0);
+		expect(d.isCommit).toBe(false);
+		expect(d.shouldDispatch).toBe(false);
+	});
+
+	it("does not treat `git log` as a commit", () => {
+		const d = detectGitCommit("git log --oneline -n 5", 0);
+		expect(d.isCommit).toBe(false);
+		expect(d.shouldDispatch).toBe(false);
+	});
+
+	it("flags `git commit --amend` as amend and suppresses dispatch", () => {
+		const d = detectGitCommit("git commit --amend --no-edit", 0);
+		expect(d.isCommit).toBe(true);
+		expect(d.isAmend).toBe(true);
+		expect(d.shouldDispatch).toBe(false);
+	});
+
+	it("flags `git commit --amend -m` as amend", () => {
+		const d = detectGitCommit('git commit --amend -m "reword"', 0);
+		expect(d.isAmend).toBe(true);
+		expect(d.shouldDispatch).toBe(false);
+	});
+
+	it("suppresses dispatch on non-zero exit code", () => {
+		const d = detectGitCommit('git commit -m "broken"', 1);
+		expect(d.isCommit).toBe(true);
+		expect(d.exitOk).toBe(false);
+		expect(d.shouldDispatch).toBe(false);
+	});
+
+	it("handles leading whitespace / chained commands", () => {
+		const d = detectGitCommit('cd repo && git commit -m "x"', 0);
+		expect(d.isCommit).toBe(true);
+		expect(d.shouldDispatch).toBe(true);
+	});
+});
+
+describe("createCommitCaptureDispatchHandler", () => {
+	it("emits systemMessage for a successful git commit", async () => {
+		const handler = createCommitCaptureDispatchHandler();
+		const result = await handler(
+			baseEvent({
+				tool_input: { command: 'git commit -m "feat: new thing"', exit_code: 0 },
+				tool_response: "[main abc1234] feat: new thing",
+			}),
+		);
+		expect(result.status).toBe("processed");
+		expect(result.systemMessage).toBe(COMMIT_CAPTURE_HINT);
+	});
+
+	it("does not emit systemMessage for `git status`", async () => {
+		const handler = createCommitCaptureDispatchHandler();
+		const result = await handler(
+			baseEvent({
+				tool_input: { command: "git status", exit_code: 0 },
+			}),
+		);
+		expect(result.status).toBe("skipped");
+		expect(result.systemMessage).toBeUndefined();
+	});
+
+	it("does not emit systemMessage for `git commit --amend`", async () => {
+		const handler = createCommitCaptureDispatchHandler();
+		const result = await handler(
+			baseEvent({
+				tool_input: {
+					command: 'git commit --amend -m "reword"',
+					exit_code: 0,
+				},
+			}),
+		);
+		expect(result.status).toBe("skipped");
+		expect(result.systemMessage).toBeUndefined();
+	});
+
+	it("does not emit systemMessage when exit code is non-zero", async () => {
+		const handler = createCommitCaptureDispatchHandler();
+		const result = await handler(
+			baseEvent({
+				tool_input: {
+					command: 'git commit -m "will fail"',
+					exit_code: 1,
+				},
+			}),
+		);
+		expect(result.status).toBe("skipped");
+		expect(result.systemMessage).toBeUndefined();
+	});
+
+	it("skips non-Bash tools entirely", async () => {
+		const handler = createCommitCaptureDispatchHandler();
+		const result = await handler(
+			baseEvent({
+				tool_name: "Write",
+				tool_input: { file_path: "/tmp/foo.ts", content: "x" },
+			}),
+		);
+		expect(result.status).toBe("skipped");
+		expect(result.systemMessage).toBeUndefined();
+	});
+
+	it("skips when tool_input is missing", async () => {
+		const handler = createCommitCaptureDispatchHandler();
+		const result = await handler(baseEvent({ tool_input: undefined }));
+		expect(result.status).toBe("skipped");
+		expect(result.systemMessage).toBeUndefined();
+	});
+
+	it("defaults to exit_code 0 when the field is absent", async () => {
+		const handler = createCommitCaptureDispatchHandler();
+		// Real Claude Code events may omit exit_code — we must still fire
+		// the hint for successful commits rather than silently skipping.
+		const result = await handler(
+			baseEvent({
+				tool_input: { command: 'git commit -m "feat: add"' },
+			}),
+		);
+		expect(result.status).toBe("processed");
+		expect(result.systemMessage).toBe(COMMIT_CAPTURE_HINT);
+	});
+});


### PR DESCRIPTION
## Summary

Closes the last two scheduled roadmap entries (#11 utility rewrites + #13 knowledge-capture commit hook):

**PostToolUse Bash subscriber** emits a `systemMessage` on successful `git commit`: *"Git commit detected. Consider dispatching @sia-knowledge-capture to capture decisions/bugs from this change."* Skips `--amend` and non-zero exits. Hook entries 9 → 10.

**15 utility-cluster skill descriptions** rewritten with superpowers-style triggers. Skill bodies unchanged. Skills: `sia-augment`, `sia-compare`, `sia-digest`, `sia-doctor`, `sia-freshness`, `sia-history`, `sia-index`, `sia-prune`, `sia-reindex`, `sia-sync`, `sia-team`, `sia-tour`, `sia-upgrade`, `sia-visualize-live`, `sia-workspace`.

No version bump.

## Test plan

- [x] 14 new tests in `tests/unit/hooks/handlers/commit-capture-dispatch.test.ts` (Bash/non-Bash, commit/amend/non-commit, exit-code branches)
- [x] `bun run typecheck` + `lint` clean
- [x] `bun run test` 2170/2171 pass (pre-existing `isWorktree` only)
- [x] `bash scripts/validate-plugin.sh` 9/9
- [x] `bash scripts/count-plugin-components.sh` — Skills 42, Agents 26, Commands 42, MCP 29, **Hook entries 10** (+1), Hook events 7