### PR TITLE
docs: refresh README + PLUGIN_README for roadmap sweep

### DIFF
--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -73,17 +73,17 @@ Color palette: **blue** (orient / explain), **green** (generate), **red** (debug
 Pruned from 74 in 1.2.1. Kept: direct MCP wrappers (`/at-time`, `/community`), the five `/nous-*` cognitive-layer commands, args-bearing shims (`/search`, `/learn`), and high-frequency short aliases (`/setup`, `/doctor`, `/capture`, `/debug`, etc.). All other skills and agents remain reachable as `/sia-<name>` and `@sia-<name>`. Phase C1 (Unreleased) folded `/stats`+`/status` into `/health` and added `/pm`, `/qa`, `/export` short aliases for the consolidated skills. See
 [PLUGIN_USAGE.md → Commands](PLUGIN_USAGE.md#commands-42) and the 1.2.1 CHANGELOG entry for the full pruning rule.
 
-## Hooks (9 entries across 7 events)
+## Hooks (10 entries across 7 events)
 
 | Event | Purpose |
 |---|---|
-| PreToolUse | Augment tool calls with graph context; Nous significance signal |
-| PostToolUse | Capture knowledge from file changes; branch-switch snapshots |
-| Stop | Detect uncaptured knowledge patterns |
-| SessionStart | Inject recent decisions + conventions |
-| PreCompact | Extract knowledge before context compaction |
-| SessionEnd | Record session statistics |
-| UserPromptSubmit | Capture prompts and detect correction/preference patterns |
+| PreToolUse | Augment tool calls with graph context; Nous significance signal; `preference-guard` denies Tier-1 "never/do not X" matches |
+| PostToolUse | Capture knowledge from file changes; branch-switch snapshots; Nous discomfort + surprise-router (T3 cross-encoder) signals; commit-capture dispatch hint on successful `git commit` |
+| Stop | Detect uncaptured knowledge patterns; drift recompute; `SubagentEpisode` write for subagent sessions |
+| SessionStart | Inject recent decisions + conventions; Nous drift check |
+| PreCompact | Promote staged entities + emit `systemMessage` with top Preferences/Episodes |
+| SessionEnd | Staging promotion + `EpisodeSummary` aggregation + mark `nous_sessions.ended_at` |
+| UserPromptSubmit | Inject top-k `sia_search` hits + open Concerns as `additionalContext` (≥ 20 char prompts, 200ms timeout) |
 
 Full event matrix and authoring guidance in [hooks/README.md](hooks/README.md).
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Sia gives your agent a typed, temporal, ontology-enforced knowledge graph that c
 
 **The core difference:** CLAUDE.md and claude-mem treat memory as flat text or key-value stores. Obsidian provides rich manual knowledge management but has no AI agent integration. Sia treats memory as a **typed, temporal, ontology-enforced knowledge graph** with native agent integration — the same data structure that makes knowledge useful to humans also makes it useful to AI agents, and knowledge flows automatically between sessions without manual curation.
 
+Every MCP tool response now carries an optional `next_steps` chaining hint that names the next natural tool call (e.g., `sia_search` → `sia_by_file`, `nous_state` → `nous_reflect` on drift warning), so the agent rarely has to guess at the follow-up.
+
 ---
 
 ## Quick Start
@@ -520,7 +522,7 @@ List, restore, and prune branch snapshots for worktree-aware graph state managem
 
 ## Nous Cognitive Layer
 
-Nous is Sia's cognitive layer — drift monitoring, self-reflection, curiosity-driven graph exploration, and anti-sycophancy guardrails. Four hooks fire automatically (SessionStart drift, PreToolUse significance, PostToolUse discomfort + surprise, Stop episode). Five MCP tools require explicit invocation:
+Nous is Sia's cognitive layer — drift monitoring, self-reflection, curiosity-driven graph exploration, and anti-sycophancy guardrails. Four hooks fire automatically (SessionStart drift, PreToolUse significance, PostToolUse discomfort + surprise, Stop episode + drift recompute). The `surprise-router` is now backed by the T3 transformer-stack cross-encoder (no longer the Phase 1 stub) — it scores prediction error on `Bash`/`Grep`/`Glob` calls and writes `surprise:<kind>` Signal nodes when the score drops below 0.7; any failure (missing model, onnxruntime absent, rerank timeout) fails open. Alongside the Nous hooks, Sia runs: `preference-guard` (PreToolUse deny for Tier-1 "never/do not X" Preferences, session-cached, fails open), UserPromptSubmit memory+concern inject (`sia_search` hits + open Concerns as `additionalContext` on every prompt ≥ 20 chars, 200ms hard timeout), PreCompact staging promotion + top-Preferences/Episodes `systemMessage`, SessionEnd final consolidation (staging promotion + `EpisodeSummary` when ≥ 3 Signals fired + marks `nous_sessions.ended_at`), and a PostToolUse commit-capture dispatch hint that nudges toward `@sia-knowledge-capture` after a successful `git commit`. 10 hook entries across 7 events total. Five MCP tools require explicit invocation:
 
 | Tool | Purpose |
 |---|---|
@@ -532,7 +534,7 @@ Nous is Sia's cognitive layer — drift monitoring, self-reflection, curiosity-d
 
 Matching slash commands — `/nous-state`, `/nous-reflect`, `/nous-curiosity`, `/nous-concern`, `/nous-modify` — mirror these tools with sensible defaults. See `CLAUDE.md` → "Nous Cognitive Layer — Tool Contract" for the authoritative semantics and anti-sycophancy rules.
 
-**Disabling Nous.** Set `nous.enabled = false` in your Sia config (defaults to `true`). When disabled, all four hooks become no-ops — no session rows, no signals, no episodes — and the MCP tools remain callable but operate against an empty working memory. Useful for debugging, tightly-scoped agent sessions, or users who prefer retrieval-only Sia.
+**Disabling Nous.** Set `nous.enabled = false` in your Sia config (defaults to `true`). When disabled, all four Nous hooks become no-ops — no session rows, no signals, no episodes — and the MCP tools remain callable but operate against an empty working memory. The non-Nous subscribers listed above (`preference-guard`, UserPromptSubmit inject, PreCompact staging, SessionEnd consolidation, commit-capture hint) are independent and continue to run. Useful for debugging, tightly-scoped agent sessions, or users who prefer retrieval-only Sia.
 
 ---
 
@@ -573,7 +575,7 @@ Skills are slash commands providing structured workflows. Invoke them in Claude 
 
 ### Development Workflow
 
-These nine skills augment standard development workflows with graph intelligence:
+These ten skills augment standard development workflows with graph intelligence:
 
 | Skill | Enhancement Over Standard Workflow |
 |---|---|
@@ -586,6 +588,7 @@ These nine skills augment standard development workflows with graph intelligence
 | `/sia-dispatch` | Community-based independence verification for parallel agents |
 | `/sia-review-respond` | Past decision context, YAGNI checks via usage patterns |
 | `/sia-verify` | Area-specific requirements, past verification failures, known gotchas |
+| `/sia-verify-before-completion` | Verify-then-claim discipline with graph-powered past-failure lookup — run before committing, creating a PR, or declaring work done |
 
 ### Visualization & Onboarding
 


### PR DESCRIPTION
Surgical documentation updates reflecting the 14 roadmap PRs (#74–#88).

## Summary

- **Nous section**: names all recent hook subscribers (preference-guard, UserPromptSubmit inject, PreCompact staging, SessionEnd consolidation, commit-capture dispatch hint); notes surprise-router is live (T3 cross-encoder, 5-layer fail-open).
- **Differentiator table intro**: adds a sentence on the `next_steps` chaining hint present on every MCP response.
- **Development Workflow table**: adds `sia-verify-before-completion` row; updates 'nine skills' → 'ten skills'.
- **PLUGIN_README.md Hooks section**: 9 → 10 entries with per-event rows rewritten to the actual subscriber surface.
- **PLUGIN_USAGE.md**: verified current, untouched.

## Test plan

- [x] `bash scripts/validate-plugin.sh` 9/9
- [x] `bash scripts/count-plugin-components.sh` counts unchanged
- [x] README.md 1181 → 1184 lines (+3, well under any cap)