### PR TITLE
fix(publish): exclude nested node_modules + frontend source from tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,48 @@
+# Nested node_modules — the big offender; 106MB from src/visualization/frontend
+**/node_modules/
+**/node_modules/**
+
+# Tests — don't ship test suites with the runtime package
+**/*.test.ts
+**/*.test.js
+**/*.test.mjs
+tests/
+**/tests/
+**/__tests__/
+**/*.spec.ts
+**/*.spec.js
+
+# Build / tooling artefacts
+*.tsbuildinfo
+*.map
+coverage/
+.nyc_output/
+.turbo/
+.next/
+
+# Dev tooling + editor
+.claude/
+.vscode/
+.idea/
+.github/
+.husky/
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
+# Misc
+.DS_Store
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Docs that are repo-only (gitignored plans + ephemeral scratch)
+docs/superpowers/plans/
+docs/scratch/
+
+# Keep the following even though they might match above:
+!.claude-plugin/
+!.claude-plugin/**

--- a/package.json
+++ b/package.json
@@ -103,6 +103,12 @@
 	},
 	"files": [
 		"src/",
+		"!src/visualization/frontend/",
+		"!**/node_modules/",
+		"!**/*.test.ts",
+		"!**/*.spec.ts",
+		"!**/tsconfig.tsbuildinfo",
+		"!**/*.map",
 		"scripts/",
 		"skills/",
 		"agents/",


### PR DESCRIPTION
Your `bun publish` was packing 106MB of `src/visualization/frontend/node_modules/` (9,379 files). Fixed.

## Before / after

| | Files | Unpacked |
|---|---|---|
| Before | 9,379 | 88.66 MB |
| After | **438** | **3.0 MB** |

## Why this happened

- `.gitignore` is never consulted by npm or bun during tarball creation.
- The `files` whitelist included `src/` without filters, pulling in the nested `node_modules` of the visualizer frontend.
- No `.npmignore` existed.

## Fixes (belt-and-suspenders)

1. **`package.json` `files` negation patterns** — explicitly excludes `src/visualization/frontend/` (source dir; not needed at runtime — `viz-api-server.ts` serves `frontend-dist/` which is the built output), plus defensive `!**/node_modules/`, test files, tsbuildinfo, source maps.
2. **`.npmignore`** — same excludes plus broader repo-hygiene (`.claude/`, `docs/`, editor configs, logs).

Verified via `bun pm pack --dry-run` — zero `node_modules` entries, zero frontend-source entries, `frontend-dist` still present.

Ready for `bun publish --access public`.