### PR TITLE
fix(publish): keep visualizer frontend source; exclude only node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
 	},
 	"files": [
 		"src/",
-		"!src/visualization/frontend/",
 		"!**/node_modules/",
 		"!**/*.test.ts",
 		"!**/*.spec.ts",


### PR DESCRIPTION
Revision to #91 based on user feedback.

Shipping the frontend React source is cheap (+19 files / +240 KB) and gives consumers the ability to read/customise/rebuild the visualizer. Only the installed-dependencies tree (`node_modules`) plus tests + build artefacts stay out.

## Numbers

| Variant | Files | Unpacked |
|---|---|---|
| Original (pre-fix) | 9,379 | 88.66 MB |
| #91 (frontend/ wholesale excluded) | 438 | 3.00 MB |
| **This PR (only node_modules excluded)** | **457** | **3.24 MB** |

## What now ships

`src/visualization/frontend/` including: React source (components, hooks, types), `index.html`, `vite.config.ts`, `tsconfig.json`, `bun.lock` (for deterministic rebuild), `package.json`.

## What still stays out

- `**/node_modules/` (the 106 MB)
- `**/*.test.ts`, `**/*.spec.ts`
- `**/tsconfig.tsbuildinfo`, `**/*.map`