### PR TITLE
fix(plugin): defensive handling for unexpanded ${CLAUDE_PLUGIN_DATA}

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
 	},
 	"metadata": {
 		"description": "Sia — persistent graph memory for AI coding agents",
-		"version": "1.3.1"
+		"version": "1.3.4"
 	},
 	"plugins": [
 		{
 			"name": "sia",
 			"source": "./",
 			"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
-			"version": "1.3.1",
+			"version": "1.3.4",
 			"author": {
 				"name": "Ramez Karim"
 			},
@@ -33,5 +33,5 @@
 			]
 		}
 	],
-	"version": "1.3.1"
+	"version": "1.3.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "sia",
-	"version": "1.3.2",
+	"version": "1.3.4",
 	"description": "Persistent graph memory for AI coding agents — bi-temporal knowledge graph with cross-session recall",
 	"author": {
 		"name": "Ramez Karim"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ All notable changes to Sia are documented here. This project adheres to
 
 - Staging catch blocks surface non-missing-table errors to stderr; null trust_tier defaults to Tier 4 strict threshold.
 
+## 1.3.2 — 2026-05-02
+
+### Fixed
+- MCP server now starts cleanly on Claude Code installs where the
+  `mcpServers.env` template substitution fails to expand
+  `${CLAUDE_PLUGIN_DATA}`. Both `scripts/start-mcp.sh` and
+  `resolveSiaHome()` now sanitize the value and fall back to `~/.sia`
+  with a single stderr breadcrumb instead of crashing on
+  `must be an absolute path: "${CLAUDE_PLUGIN_DATA}"`.
+
 ## [1.3.3] — 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to Sia are documented here. This project adheres to
 
 - Staging catch blocks surface non-missing-table errors to stderr; null trust_tier defaults to Tier 4 strict threshold.
 
-## 1.3.2 — 2026-05-02
+## [1.3.4] — 2026-05-02
 
 ### Fixed
 - MCP server now starts cleanly on Claude Code installs where the

--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -106,7 +106,7 @@ If you see this on the Claude Code MCP debug log:
 > `error: CLAUDE_PLUGIN_DATA must be an absolute path, got: "${CLAUDE_PLUGIN_DATA}"`
 
 …your Claude Code build is not expanding the `${CLAUDE_PLUGIN_DATA}`
-template in the plugin's `mcpServers.env` block. Sia v1.3.2 and later
+template in the plugin's `mcpServers.env` block. Sia v1.3.4 and later
 detect this and fall back to `~/.sia/`, printing a one-line warning to
 stderr:
 

--- a/PLUGIN_README.md
+++ b/PLUGIN_README.md
@@ -96,3 +96,21 @@ Full event matrix and authoring guidance in [hooks/README.md](hooks/README.md).
 
 - **Per-project:** Graph database in `~/.sia/repos/{repo-hash}/`
 - **Plugin-global:** Configuration and models in `$CLAUDE_PLUGIN_DATA/`
+
+## Troubleshooting
+
+### MCP server fails with `${CLAUDE_PLUGIN_DATA}` literal
+
+If you see this on the Claude Code MCP debug log:
+
+> `error: CLAUDE_PLUGIN_DATA must be an absolute path, got: "${CLAUDE_PLUGIN_DATA}"`
+
+…your Claude Code build is not expanding the `${CLAUDE_PLUGIN_DATA}`
+template in the plugin's `mcpServers.env` block. Sia v1.3.2 and later
+detect this and fall back to `~/.sia/`, printing a one-line warning to
+stderr:
+
+> `[sia] warning: CLAUDE_PLUGIN_DATA='${CLAUDE_PLUGIN_DATA}' looks malformed; ignoring (using default home)`
+
+The server will still start. To file the upstream bug, include your
+`claude --version` and the platform (Linux distro / macOS).

--- a/scripts/start-mcp.sh
+++ b/scripts/start-mcp.sh
@@ -7,5 +7,30 @@ PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
 
 source "$PLUGIN_ROOT/scripts/ensure-runtime.sh" "$PLUGIN_ROOT"
 
+# Sanitize plugin-data env vars: Claude Code is supposed to expand
+# ${CLAUDE_PLUGIN_DATA} inline (see plugin reference docs), but on at least
+# one Linux build the literal "${CLAUDE_PLUGIN_DATA}" leaks through and
+# crashes the server. Drop any obviously malformed values so resolveSiaHome
+# can fall through to its standalone default.
+sanitize_plugin_data() {
+	local var_name="$1"
+	local value="${!var_name-}"
+	# Trim surrounding whitespace.
+	value="${value#"${value%%[![:space:]]*}"}"
+	value="${value%"${value##*[![:space:]]}"}"
+	if [[ -z "$value" ]] \
+		|| [[ "$value" == *'${'* ]] \
+		|| [[ "$value" != /* ]]; then
+		if [[ -n "${!var_name-}" ]]; then
+			echo "[sia] warning: $var_name='${!var_name}' looks malformed; ignoring (using default home)" >&2
+		fi
+		unset "$var_name"
+	else
+		export "$var_name=$value"
+	fi
+}
+sanitize_plugin_data CLAUDE_PLUGIN_DATA
+sanitize_plugin_data SIA_HOME
+
 export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
 exec bun run "$PLUGIN_ROOT/scripts/start-mcp.ts"

--- a/src/hooks/handlers/user-prompt-submit.ts
+++ b/src/hooks/handlers/user-prompt-submit.ts
@@ -431,7 +431,7 @@ function extractKeywords(prompt: string): string[] {
 	]);
 	const seen = new Set<string>();
 	const out: string[] = [];
-	for (const tok of prompt.toLowerCase().split(/[^a-z0-9_\-]+/)) {
+	for (const tok of prompt.toLowerCase().split(/[^a-z0-9_-]+/)) {
 		if (tok.length < 4) continue;
 		if (STOP.has(tok)) continue;
 		if (seen.has(tok)) continue;

--- a/src/hooks/memoize.ts
+++ b/src/hooks/memoize.ts
@@ -43,14 +43,10 @@ export async function memoizeForTurn<T>(
 		return bucket.get(key) as T;
 	}
 
-	try {
-		const value = await compute();
-		bucket.set(key, value);
-		return value;
-	} catch (err) {
-		// Do not cache failures — caller may want to retry next turn.
-		throw err;
-	}
+	// Failures from compute() propagate without being cached — caller may retry next turn.
+	const value = await compute();
+	bucket.set(key, value);
+	return value;
 }
 
 /**

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -16,14 +16,25 @@ export type TaskType = "orientation" | "feature" | "bug-fix" | "regression" | "r
  * CLAUDE_PLUGIN_DATA, ensure it is set before this module is first imported.
  */
 export function resolveSiaHome(): string {
-	const pluginData = process.env.CLAUDE_PLUGIN_DATA;
-	if (pluginData !== undefined && pluginData !== "") {
-		if (!isAbsolute(pluginData)) {
-			throw new Error(`CLAUDE_PLUGIN_DATA must be an absolute path, got: "${pluginData}"`);
+	const raw = process.env.CLAUDE_PLUGIN_DATA;
+	const pluginData = raw?.trim() ?? "";
+
+	// Treat empty / unexpanded-template values as "not set" — fall through to default.
+	// Healthy Claude Code installs never produce these; broken installs do, and we
+	// would rather degrade to standalone mode than crash the MCP server.
+	if (pluginData === "" || pluginData.includes("${")) {
+		if (raw !== undefined && raw !== "") {
+			process.stderr.write(
+				`sia: CLAUDE_PLUGIN_DATA="${raw}" looks malformed (template not expanded?); falling back to ~/.sia\n`,
+			);
 		}
-		return pluginData;
+		return join(homedir(), ".sia");
 	}
-	return join(homedir(), ".sia");
+
+	if (!isAbsolute(pluginData)) {
+		throw new Error(`CLAUDE_PLUGIN_DATA must be an absolute path, got: "${raw}"`);
+	}
+	return pluginData;
 }
 
 export const SIA_HOME: string = resolveSiaHome();

--- a/tests/unit/graph/staging.test.ts
+++ b/tests/unit/graph/staging.test.ts
@@ -525,9 +525,7 @@ describe("promoteStagedEntities", () => {
 			execute: async (sql, params) => {
 				const res = await real.execute(sql, params);
 				if (/FROM\s+memory_staging/i.test(sql) && /SELECT\s+\*/i.test(sql)) {
-					res.rows = res.rows.map((r) =>
-						r.id === stagedId ? { ...r, trust_tier: null } : r,
-					);
+					res.rows = res.rows.map((r) => (r.id === stagedId ? { ...r, trust_tier: null } : r));
 				}
 				return res;
 			},

--- a/tests/unit/shared/config.test.ts
+++ b/tests/unit/shared/config.test.ts
@@ -149,4 +149,22 @@ describe("SIA_HOME resolution", () => {
 		process.env.CLAUDE_PLUGIN_DATA = "relative/path";
 		expect(() => resolveSiaHome()).toThrow("must be an absolute path");
 	});
+
+	it("should fall back to ~/.sia when CLAUDE_PLUGIN_DATA contains an unexpanded template", () => {
+		process.env.CLAUDE_PLUGIN_DATA = "$" + "{CLAUDE_PLUGIN_DATA}";
+		const home = resolveSiaHome();
+		expect(home).toContain(".sia");
+		expect(home).not.toContain("${");
+	});
+
+	it("should fall back to ~/.sia when CLAUDE_PLUGIN_DATA is whitespace only", () => {
+		process.env.CLAUDE_PLUGIN_DATA = "   \n";
+		const home = resolveSiaHome();
+		expect(home).toContain(".sia");
+	});
+
+	it("should accept a whitespace-padded absolute path", () => {
+		process.env.CLAUDE_PLUGIN_DATA = " /tmp/padded-plugin-data\n";
+		expect(resolveSiaHome()).toBe("/tmp/padded-plugin-data");
+	});
 });


### PR DESCRIPTION
## Summary
- `scripts/start-mcp.sh` sanitizes `CLAUDE_PLUGIN_DATA` / `SIA_HOME` before exec'ing Bun (unsets if empty, contains `${`, or non-absolute; trims whitespace; emits one stderr breadcrumb).
- `src/shared/config.ts::resolveSiaHome()` mirrors the guard so any non-MCP entry point (CLI, hooks) is safe.
- Real caller bugs (relative paths) still throw — env-delivery bugs degrade to `~/.sia`.
- Bumps version to **1.3.4** (skips past existing `## [1.3.3]` CHANGELOG entry; plugin.json was at 1.3.1, so 1.3.2 would have been non-monotonic).

## Why
A user installing Sia on Linux Claude Code reported the MCP server crashing with:
> `error: CLAUDE_PLUGIN_DATA must be an absolute path, got: "${CLAUDE_PLUGIN_DATA}"`

The `${CLAUDE_PLUGIN_DATA}` template inside `mcpServers.env` was not expanded by the runtime. Per [Anthropic's plugin reference docs](https://code.claude.com/docs/en/plugins-reference) it *should* expand inline anywhere in `mcpServers` configs, so this is an upstream Claude Code bug — but our plugin shouldn't crash because of it. This PR is pure defense-in-depth; `plugin.json`'s `mcpServers` block is unchanged and continues to follow Anthropic's documented recommended pattern.

## Behavior matrix
| `CLAUDE_PLUGIN_DATA` value | Old behavior | New behavior |
|---|---|---|
| unset | `~/.sia` | `~/.sia` (unchanged) |
| `""` | `~/.sia` | `~/.sia` (unchanged) |
| `"   "` | throw | `~/.sia` + stderr warning |
| `"${CLAUDE_PLUGIN_DATA}"` | throw | `~/.sia` + stderr warning |
| `"relative/path"` | throw | throw (unchanged — real caller bug) |
| `"/abs/path"` | `/abs/path` | `/abs/path` (unchanged) |
| `" /abs/path\n"` | throw | `/abs/path` (trimmed, accepted) |

## Test plan
- [x] `bun run test -- tests/unit/shared/config.test.ts` — 16 cases pass (13 existing + 3 new for unexpanded-template / whitespace-only / whitespace-padded)
- [x] `bun run typecheck` clean
- [x] Manual smoke: `CLAUDE_PLUGIN_DATA='${CLAUDE_PLUGIN_DATA}' bash scripts/start-mcp.sh` reaches `sia: MCP server started` (warning fires as expected)
- [x] Manual smoke: healthy absolute path starts cleanly with no warning, DB files created
- [ ] Reviewer to confirm `mcpServers` block in `plugin.json` is unchanged